### PR TITLE
Feat: 공통 button 컴포넌트 추가

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,52 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { clsx } from 'clsx';
+import { forwardRef } from 'react';
+
+const buttonVariants = cva(
+  'inline-flex cursor-pointer items-center justify-center font-medium transition-colors',
+  {
+    variants: {
+      variant: {
+        primary:
+          'border-2 border-transparent bg-fuchsia-400 text-white hover:bg-fuchsia-500',
+        secondary: 'border-2 border-transparent bg-gray-200 hover:bg-gray-300',
+        outline:
+          'border-2 border-fuchsia-400 text-fuchsia-400 hover:bg-fuchsia-400 hover:text-white hover:border-fuchsia-400',
+      },
+      shape: {
+        default: 'rounded-md',
+        pill: 'rounded-full',
+      },
+      size: {
+        sm: 'px-2 py-1.5 text-xs',
+        md: 'px-4 py-2 text-sm',
+        lg: 'px-10 py-3 text-base',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      shape: 'default',
+      size: 'md',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  className?: string;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, shape, size, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={clsx(buttonVariants({ variant, shape, size }), className)}
+        {...props}
+      />
+    );
+  },
+);
+
+Button.displayName = 'Button';


### PR DESCRIPTION
## 🚀 PR 요약

공통 버튼 컴포넌트 생성
- variant: primary, secondary, outline
- shape: default, pill
- size: sm, md, lg
- defaultVariants: primary, default, md

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.
- [x] 이슈 브랜치 -> develop PR은 **squash and merge**, develop -> main PR은 **rebase and merge**를 선택했습니다.

## 🗒️ 기타 참고사항

왼: default / 오: pill
<img width="1897" height="907" alt="image" src="https://github.com/user-attachments/assets/ccdaa5ef-cf25-4abe-9279-b16f47812ecc" />

배경색 변경 시 다음처럼 사용하시면 됩니다.
```
          <Button size="sm" variant="secondary" className="bg-white text-black">
            primary
          </Button>

          <Button
            size="sm"
            variant="secondary"
            className="bg-yellow-300 hover:bg-yellow-400"
          >
            primary
          </Button>
```
<img width="933" height="374" alt="image" src="https://github.com/user-attachments/assets/950540d7-5c61-44f7-8dc8-3317bce5bb7e" />


## 🔗 연관된 이슈

> closes #12 
