### PR TITLE
Refactor: 공통 Card 컴포넌트 리팩토링

### DIFF
--- a/src/components/common/card/IdolCard.tsx
+++ b/src/components/common/card/IdolCard.tsx
@@ -7,11 +7,11 @@ import type { IdolCardProps } from './card.types';
 function IdolCard({
   imageSrc = '',
   title = '',
-  details,
+  detail,
   className,
   ...rest
 }: IdolCardProps) {
-  const { idolGroup, position } = details;
+  const { idolGroup, position } = detail;
   const [isLiked, setIsLiked] = useState<boolean>();
 
   const handleClickLike = (e: React.MouseEvent) => {

--- a/src/components/common/card/card.types.ts
+++ b/src/components/common/card/card.types.ts
@@ -1,11 +1,16 @@
-export interface AnimationCardProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+export type CardTypes = 'animation' | 'idol';
+
+interface BaseCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  type: CardTypes;
+}
+
+export interface AnimationCardProps extends BaseCardProps {
   title: string;
   description: string;
 }
 
-export interface IdolCardProps extends React.HTMLAttributes<HTMLDivElement> {
-  imageSrc?: string;
+export interface IdolCardProps extends BaseCardProps {
   title: string;
+  imageSrc?: string;
   details: { idolGroup: string; position: string };
 }

--- a/src/components/common/card/card.types.ts
+++ b/src/components/common/card/card.types.ts
@@ -12,5 +12,5 @@ export interface AnimationCardProps extends BaseCardProps {
 export interface IdolCardProps extends BaseCardProps {
   title: string;
   imageSrc?: string;
-  details: { idolGroup: string; position: string };
+  detail: { idolGroup: string; position: string };
 }

--- a/src/components/common/card/index.tsx
+++ b/src/components/common/card/index.tsx
@@ -1,0 +1,22 @@
+import AnimationCard from './AnimationCard';
+import type {
+  AnimationCardProps,
+  CardTypes,
+  IdolCardProps,
+} from './card.types';
+import IdolCard from './IdolCard';
+
+const CardMap: Record<CardTypes, React.ComponentType<any>> = {
+  animation: AnimationCard,
+  idol: IdolCard,
+};
+
+export default function Card(
+  props:
+    | ({ type: 'animation' } & Omit<AnimationCardProps, 'type'>)
+    | ({ type: 'idol' } & Omit<IdolCardProps, 'type'>),
+) {
+  const { type, ...rest } = props;
+  const Component = CardMap[type];
+  return <Component {...rest} />;
+}


### PR DESCRIPTION
## 🚀 PR 요약

공통 Card 컴포넌트 리팩토링

- `<Card />`에 props로 type 전달하여 컴포넌트 사용할 수 있도록 **index.tsx** 추가
- Card 컴포넌트 타입 정리
- 네이밍 컨벤션에 맞춰 객체 props인 details를 **detail**로 수정

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

`<Card />`에 type, title, description(`AnimationCard`일 경우), detail(`IdolCard`일 경우)를 props로 전달하여 사용하시면 됩니다.

## 🔗 연관된 이슈

> closes #33
