### PR TITLE
Refactor: onkeydown 로직 함수로 분리

### DIFF
--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import React, { useEffect, useRef, useState } from 'react';
+
 import { handleToggleOnKeyDown } from '@/utils/handleToggleOnKeyDown';
 
 interface SelectProps {

--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import React, { useEffect, useRef, useState } from 'react';
+import { handleToggleOnKeyDown } from '@/utils/handleToggleOnKeyDown';
 
 interface SelectProps {
   list: Array<{ id: string | number; label: string }>;
@@ -53,12 +54,7 @@ export default function Select({
         className,
       )}
       onClick={() => setShowOptions(prev => !prev)}
-      onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          setShowOptions(prev => !prev);
-        }
-      }}
+      onKeyDown={e => handleToggleOnKeyDown(e, setShowOptions)}
       ref={selectRef}
     >
       <label htmlFor="custom-select">{currentValue}</label>
@@ -90,7 +86,7 @@ export default function Select({
               onKeyDown={e => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  handleOnChangeSelectValue(e as any); // 타입 강제 변환 (필요하면)
+                  handleOnChangeSelectValue(e as any);
                 }
               }}
             >

--- a/src/utils/handleToggleOnKeyDown.ts
+++ b/src/utils/handleToggleOnKeyDown.ts
@@ -1,0 +1,9 @@
+export const handleToggleOnKeyDown = (
+  e: React.KeyboardEvent,
+  setShowOptions: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    setShowOptions(prev => !prev);
+  }
+};


### PR DESCRIPTION
## 🚀 PR 요약

onkeydown 로직 함수로 분리 및 접근성 개선

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

- handleToggleOnKeyDown: 토글 열고 닫기 기능을 담당합니다. 다른 컴포넌트에서도 재사용할 수 있는 함수라 utils 폴더로 옮겼습니다.
- handleOptionKeyDown: 옵션 목록을 탐색/선택하는 Select 컴포넌트에 특화된 로직이라 따로 분리하지 않았습니다.
- 위/아래 화살표 키를 사용한 옵션 간 이동이 가능하도록 접근성을 개선하였습니다. 
- 키보드로 탐색을 시작하면 포커스 효과가 보이게 하였습니다.

https://github.com/user-attachments/assets/8bcc78c4-c3b5-452b-9ad4-9708b5d95bf0


## 🔗 연관된 이슈

> closes #38 
