### PR TITLE
Feat/26 today schedule

### DIFF
--- a/src/components/common/dateSchedule/DateScheduleItem.tsx
+++ b/src/components/common/dateSchedule/DateScheduleItem.tsx
@@ -1,17 +1,18 @@
-import { useMemo, useState } from 'react';
 import {
-  StarIcon as StarOutline,
   BellIcon as BellOutline,
+  StarIcon as StarOutline,
   TrashIcon,
 } from '@heroicons/react/24/outline';
 import {
-  StarIcon as StarSolid,
   BellIcon as BellSolid,
   PencilIcon,
+  StarIcon as StarSolid,
 } from '@heroicons/react/24/solid';
+import clsx from 'clsx';
+import React, { useState } from 'react';
+
 import type { Schedule, UserRole } from './dateSchedule.types';
 import { formatDateSlash } from './dateSchedule.utils';
-import clsx from 'clsx';
 
 type Props = {
   item: Schedule;
@@ -42,74 +43,76 @@ export default function DateScheduleItem({
   const handleEdit = () => onEditClick?.(item.id);
   const handleDelete = () => onDeleteClick?.(item.id);
 
-  const actions = useMemo(() => {
-    switch (role) {
-      case 'fan':
-        return [
-          <button
-            key="bm"
-            type="button"
-            aria-label="즐겨찾기"
-            className={iconBtn}
-            onClick={handleBookmark}
-          >
-            {item.isBookmarked ? (
-              <StarSolid className={clsx(iconSize, iconColor)} />
-            ) : (
-              <StarOutline className={clsx(iconSize, iconColor)} />
-            )}
-          </button>,
-        ];
-      case 'favorites':
-        return [
-          <button
-            key="bm"
-            type="button"
-            aria-label="즐겨찾기"
-            className={iconBtn}
-            onClick={handleBookmark}
-          >
+  let actions: React.ReactNode[] = [];
+  switch (role) {
+    case 'fan':
+      actions = [
+        <button
+          key="bm"
+          type="button"
+          aria-label="즐겨찾기"
+          className={iconBtn}
+          onClick={handleBookmark}
+        >
+          {item.isBookmarked ? (
             <StarSolid className={clsx(iconSize, iconColor)} />
-          </button>,
-          <button
-            key="nf"
-            type="button"
-            aria-label="알림 설정"
-            className={iconBtn}
-            onClick={handleNotify}
-          >
-            {item.isNotified ? (
-              <BellSolid className={clsx(iconSize, iconColor)} />
-            ) : (
-              <BellOutline className={clsx(iconSize, iconColor)} />
-            )}
-          </button>,
-        ];
-      case 'manager':
-        return [
-          <button
-            key="ed"
-            type="button"
-            aria-label="수정"
-            className={iconBtn}
-            onClick={handleEdit}
-          >
-            <PencilIcon className={clsx(iconSize, iconColor)} />
-          </button>,
-          <button
-            key="del"
-            type="button"
-            aria-label="삭제"
-            className={iconBtn}
-            onClick={handleDelete}
-          >
-            <TrashIcon className={clsx(iconSize, iconColor)} />
-          </button>,
-        ];
-      default:
-        return [];
-    }
-  }, [item.id, role, item.isBookmarked, item.isNotified]);
+          ) : (
+            <StarOutline className={clsx(iconSize, iconColor)} />
+          )}
+        </button>,
+      ];
+      break;
+    case 'favorites':
+      actions = [
+        <button
+          key="bm"
+          type="button"
+          aria-label="즐겨찾기"
+          className={iconBtn}
+          onClick={handleBookmark}
+        >
+          <StarSolid className={clsx(iconSize, iconColor)} />
+        </button>,
+        <button
+          key="nf"
+          type="button"
+          aria-label="알림 설정"
+          className={iconBtn}
+          onClick={handleNotify}
+        >
+          {item.isNotified ? (
+            <BellSolid className={clsx(iconSize, iconColor)} />
+          ) : (
+            <BellOutline className={clsx(iconSize, iconColor)} />
+          )}
+        </button>,
+      ];
+      break;
+    case 'manager':
+      actions = [
+        <button
+          key="ed"
+          type="button"
+          aria-label="수정"
+          className={iconBtn}
+          onClick={handleEdit}
+        >
+          <PencilIcon className={clsx(iconSize, iconColor)} />
+        </button>,
+        <button
+          key="del"
+          type="button"
+          aria-label="삭제"
+          className={iconBtn}
+          onClick={handleDelete}
+        >
+          <TrashIcon className={clsx(iconSize, iconColor)} />
+        </button>,
+      ];
+      break;
+    default:
+      actions = [];
+  }
 
   return (
     <li className="rounded-2xl transition hover:bg-gray-50">

--- a/src/components/common/dateSchedule/DateScheduleItem.tsx
+++ b/src/components/common/dateSchedule/DateScheduleItem.tsx
@@ -1,0 +1,162 @@
+import { useMemo, useState } from 'react';
+import {
+  StarIcon as StarOutline,
+  BellIcon as BellOutline,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+import {
+  StarIcon as StarSolid,
+  BellIcon as BellSolid,
+  PencilIcon,
+} from '@heroicons/react/24/solid';
+import type { Schedule, UserRole } from './dateSchedule.types';
+import { formatDateSlash } from './dateSchedule.utils';
+import clsx from 'clsx';
+
+type Props = {
+  item: Schedule;
+  role: UserRole;
+  onBookmarkToggle?: (id: string) => void;
+  onNotifyToggle?: (id: string) => void;
+  onEditClick?: (id: string) => void;
+  onDeleteClick?: (id: string) => void;
+};
+
+const iconSize = 'h-5 w-5 sm:h-6 sm:w-6';
+const iconColor = 'text-fuchsia-600';
+const iconBtn =
+  'inline-flex h-8 w-8 sm:h-9 sm:w-9 items-center justify-center rounded-md hover:bg-fuchsia-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400';
+
+export default function DateScheduleItem({
+  item,
+  role,
+  onBookmarkToggle,
+  onNotifyToggle,
+  onEditClick,
+  onDeleteClick,
+}: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleToggleOpen = () => setIsOpen(p => !p);
+  const handleBookmark = () => onBookmarkToggle?.(item.id);
+  const handleNotify = () => onNotifyToggle?.(item.id);
+  const handleEdit = () => onEditClick?.(item.id);
+  const handleDelete = () => onDeleteClick?.(item.id);
+
+  const actions = useMemo(() => {
+    switch (role) {
+      case 'fan':
+        return [
+          <button
+            key="bm"
+            type="button"
+            aria-label="즐겨찾기"
+            className={iconBtn}
+            onClick={handleBookmark}
+          >
+            {item.isBookmarked ? (
+              <StarSolid className={clsx(iconSize, iconColor)} />
+            ) : (
+              <StarOutline className={clsx(iconSize, iconColor)} />
+            )}
+          </button>,
+        ];
+      case 'favorites':
+        return [
+          <button
+            key="bm"
+            type="button"
+            aria-label="즐겨찾기"
+            className={iconBtn}
+            onClick={handleBookmark}
+          >
+            <StarSolid className={clsx(iconSize, iconColor)} />
+          </button>,
+          <button
+            key="nf"
+            type="button"
+            aria-label="알림 설정"
+            className={iconBtn}
+            onClick={handleNotify}
+          >
+            {item.isNotified ? (
+              <BellSolid className={clsx(iconSize, iconColor)} />
+            ) : (
+              <BellOutline className={clsx(iconSize, iconColor)} />
+            )}
+          </button>,
+        ];
+      case 'manager':
+        return [
+          <button
+            key="ed"
+            type="button"
+            aria-label="수정"
+            className={iconBtn}
+            onClick={handleEdit}
+          >
+            <PencilIcon className={clsx(iconSize, iconColor)} />
+          </button>,
+          <button
+            key="del"
+            type="button"
+            aria-label="삭제"
+            className={iconBtn}
+            onClick={handleDelete}
+          >
+            <TrashIcon className={clsx(iconSize, iconColor)} />
+          </button>,
+        ];
+      default:
+        return [];
+    }
+  }, [item.id, role, item.isBookmarked, item.isNotified]);
+
+  return (
+    <li className="rounded-2xl transition hover:bg-gray-50">
+      <div className="flex min-h-[64px] items-center overflow-hidden rounded-lg bg-fuchsia-100 py-3 pr-8 pl-12 sm:min-h-[72px] sm:py-4 sm:pr-10 sm:pl-16 md:min-h-[80px] md:pr-12 md:pl-20">
+        <button
+          type="button"
+          onClick={handleToggleOpen}
+          aria-expanded={isOpen}
+          aria-controls={`schedule-detail-${item.id}`}
+          className="mr-2 shrink-0 basis-[100px] text-left sm:mr-3 sm:basis-[112px] md:mr-4 md:basis-[120px]"
+        >
+          <span className="text-base whitespace-nowrap text-gray-700 tabular-nums select-none sm:text-lg">
+            {item.time}
+          </span>
+        </button>
+
+        <button
+          type="button"
+          onClick={handleToggleOpen}
+          aria-expanded={isOpen}
+          aria-controls={`schedule-detail-${item.id}`}
+          title={item.summary}
+          className="min-w-0 flex-1 truncate pl-1 text-left sm:pl-2 md:pl-3"
+        >
+          <span className="block text-base text-gray-700 sm:text-lg">
+            {item.summary}
+          </span>
+        </button>
+
+        <div className="shrink-0 basis-[88px] sm:basis-[100px] md:basis-[108px]">
+          <div className="flex justify-end gap-1">{actions}</div>
+        </div>
+      </div>
+
+      {isOpen && (
+        <div
+          id={`schedule-detail-${item.id}`}
+          className="rounded-xl bg-fuchsia-50 p-3 pl-[72px] text-sm text-gray-800 sm:p-4 sm:pl-[84px] sm:text-base md:pl-[96px]"
+        >
+          <p className="font-medium">{item.title}</p>
+          <p className="mt-2">장소: {item.location}</p>
+          <p>날짜: {formatDateSlash(item.dateISO)}</p>
+          {item.participants.length > 0 && (
+            <p>참여 아이돌: {item.participants.join(', ')}</p>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/components/common/dateSchedule/DateScheduleList.tsx
+++ b/src/components/common/dateSchedule/DateScheduleList.tsx
@@ -1,0 +1,64 @@
+import clsx from 'clsx';
+import DateScheduleItem from './DateScheduleItem';
+import type { DateScheduleListProps } from './dateSchedule.types';
+import {
+  filterByDate,
+  sortByTimeAsc,
+  formatMonthDay,
+} from './dateSchedule.utils';
+import { CalendarIcon } from '@heroicons/react/24/solid';
+
+function DateScheduleList({
+  role,
+  selectedDate,
+  schedules,
+  onBookmarkToggle,
+  onNotifyToggle,
+  onEditClick,
+  onDeleteClick,
+  className,
+}: DateScheduleListProps) {
+  const items = sortByTimeAsc(filterByDate(schedules, selectedDate));
+
+  return (
+    <section
+      className={clsx(
+        'w-full rounded-2xl border border-gray-200 bg-white shadow-md',
+        'p-3 md:p-4',
+        'mt-2',
+        'flex flex-col',
+        className,
+      )}
+      aria-label={role === 'favorites' ? '즐겨찾기한 일정' : '날짜별 일정'}
+    >
+      <div className="mt-2 mb-5 flex items-center gap-2 pl-1">
+        <CalendarIcon className="h-7 w-7 text-fuchsia-600 sm:h-8 sm:w-8" />
+        <h2 className="text-xl font-semibold md:text-2xl">
+          {formatMonthDay(selectedDate)} 스케줄
+        </h2>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="rounded-xl bg-gray-50 py-6 text-center text-sm text-gray-400">
+          선택한 날짜에 등록된 일정이 없습니다.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2.5 md:gap-3">
+          {items.slice(0, 4).map(item => (
+            <DateScheduleItem
+              key={item.id}
+              item={item}
+              role={role}
+              onBookmarkToggle={onBookmarkToggle}
+              onNotifyToggle={onNotifyToggle}
+              onEditClick={onEditClick}
+              onDeleteClick={onDeleteClick}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default DateScheduleList;

--- a/src/components/common/dateSchedule/DateScheduleList.tsx
+++ b/src/components/common/dateSchedule/DateScheduleList.tsx
@@ -1,12 +1,13 @@
+import { CalendarIcon } from '@heroicons/react/24/solid';
 import clsx from 'clsx';
-import DateScheduleItem from './DateScheduleItem';
+
 import type { DateScheduleListProps } from './dateSchedule.types';
 import {
   filterByDate,
-  sortByTimeAsc,
   formatMonthDay,
+  sortByTimeAsc,
 } from './dateSchedule.utils';
-import { CalendarIcon } from '@heroicons/react/24/solid';
+import DateScheduleItem from './DateScheduleItem';
 
 function DateScheduleList({
   role,

--- a/src/components/common/dateSchedule/dateSchedule.types.ts
+++ b/src/components/common/dateSchedule/dateSchedule.types.ts
@@ -1,0 +1,24 @@
+export type UserRole = 'manager' | 'idol' | 'fan' | 'favorites';
+
+export type Schedule = {
+  id: string;
+  dateISO: string;
+  time: string;
+  summary: string;
+  title: string;
+  location: string;
+  participants: string[];
+  isBookmarked?: boolean;
+  isNotified?: boolean;
+};
+
+export type DateScheduleListProps = {
+  role: UserRole;
+  selectedDate: string;
+  schedules: Schedule[];
+  onBookmarkToggle?: (id: string) => void;
+  onNotifyToggle?: (id: string) => void;
+  onEditClick?: (id: string) => void;
+  onDeleteClick?: (id: string) => void;
+  className?: string;
+};

--- a/src/components/common/dateSchedule/dateSchedule.utils.ts
+++ b/src/components/common/dateSchedule/dateSchedule.utils.ts
@@ -1,0 +1,39 @@
+import type { Schedule } from './dateSchedule.types';
+
+// ========== 스케줄 데이터 처리 ==========
+
+/** 선택한 날짜만 필터링 */
+export function filterByDate(items: Schedule[], dateISO: string): Schedule[] {
+  return items.filter(it => it.dateISO === dateISO);
+}
+
+/** 시간 오름차순 정렬 ('HH:mm' 가정) */
+export function sortByTimeAsc(items: Schedule[]): Schedule[] {
+  return [...items].sort((a, b) => a.time.localeCompare(b.time));
+}
+
+// ========== 날짜 포맷 변환 ==========
+
+/** 'YYYY-MM-DD' -> 'YYYY/MM/DD' (일반적인 날짜 표시) */
+export function formatDateSlash(d: string): string {
+  return d.replaceAll('-', '/');
+}
+
+/** 'YYYY-MM-DD' -> 'YYYY.MM.DD' (. 날짜 표시) */
+export function formatDateDot(d: string): string {
+  return d.replaceAll('-', '.');
+}
+
+/** 'YYYY-MM-DD' -> 'M/D' (간단한 월일 표시) */
+export const formatMonthDay = (dateISO: string) => {
+  const [, m, d] = dateISO.split('-');
+  return `${Number(m)}/${Number(d)}`;
+};
+
+/** Date -> 'YYYY-MM-DD' (캘린더 연동용) */
+export function toDateISO(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}


### PR DESCRIPTION
## 🚀 PR 요약
날짜별 스케줄 **조회 공용 컴포넌트**(DateScheduleList / DateScheduleItem)를 추가하고, 역할별 액션·반응형·접근성을 적용했습니다.

## ✏️ 변경 유형
- [x] feat: 새로운 기능 추가
- [x] style: Tailwind 클래스 정리 및 시각 톤 맞춤(테두리/그림자/간격)
- [x] fix: 아코디언 확장 시 겹침/간격 이슈 보정

## 📁 변경된 파일
```
src/components/common/dateSchedule/
├── DateScheduleList.tsx        # 메인 컴포넌트 (섹션 래퍼 + 목록 관리)
├── DateScheduleItem.tsx        # 개별 스케줄 아이템 (아코디언 + 역할별 액션)
├── dateSchedule.types.ts       # Schedule, UserRole, Props 타입 정의
└── dateSchedule.utils.ts       # filterByDate, sortByTimeAsc, formatMonthDay
```

## 🗒️ 변경 상세
### 컴포넌트 구조
- **DateScheduleList**
  - 섹션 래퍼: `w-full`, `rounded-2xl`, `border border-gray-200`, `shadow-md`
  - 헤더: 캘린더 아이콘 + `formatMonthDay` 타이틀
  - 목록: 날짜 기준 필터/정렬 후 최대 4개 렌더, 빈 상태 문구 처리
- **DateScheduleItem**
  - 좌측 고정 시간 칼럼(`basis-[100px] / sm:112px / md:120px`, `tabular-nums`)
  - 중앙 요약 텍스트 `truncate`
  - 오른쪽 역할별 액션 아이콘(버튼 focus ring 포함)
  - 아코디언 상세(제목/장소/날짜/참여자), 버튼에 `aria-expanded`/`aria-controls`

### 역할별 액션 분기
```tsx
// fan: 즐겨찾기 토글만
<StarIcon /> // 빈 별 / 채운 별

// favorites: 즐겨찾기(고정) + 알림 토글  
<StarSolid /> + <BellIcon />

// manager: 수정/삭제 권한
<PencilIcon /> + <TrashIcon />

// idol: 액션 없음 (레이아웃 일관성 유지)
```

### 레이아웃/스타일 핵심 포인트
- **반응형 간격**: `gap-2.5 md:gap-3`, `p-3 md:p-4`
- **아이템 최소 높이**: `min-h-[64px] sm:min-h-[72px] md:min-h-[80px]`
- **액션 버튼 히트영역**: `h-8 w-8`(sm: `h-9 w-9`), hover 배경·focus ring 적용
- **우측 액션 컨테이너**: `basis-[88px] sm:[100px] md:[108px]`
- **시각적 톤**: `border-gray-200` + `shadow-md` + `bg-fuchsia-100/50`

### 접근성 개선사항
- **시맨틱 마크업**: `<section>`, `<ul>`, `<li>` 구조
- **역할별 라벨**: `aria-label={role === 'favorites' ? '즐겨찾기한 일정' : '날짜별 일정'}`
- **아코디언 접근성**: `aria-expanded`, `aria-controls` 연결
- **아이콘 버튼 라벨**: `aria-label="즐겨찾기"`, `aria-label="수정"` 등

### 해결한 기술적 이슈
- ✅ **아코디언 겹침 문제**: `flex-col + gap` 구조로 자연스러운 확장
- ✅ **불일치한 행 높이**: `min-h` 통일로 시각적 일관성 확보
- ✅ **터치 영역 부족**: 버튼 히트영역 `44px` 이상 확보 (접근성 가이드라인)
- ✅ **긴 텍스트 오버플로우**: `truncate` + `title` 속성으로 전체 내용 확인 가능
- ✅ **useMemo 최적화 이슈**: 불필요한 의존성 배열 제거하여 ESLint 경고 해결
- ✅ **TypeScript 타입 에러**: `React.ReactNode[]` 타입 적용으로 빌드 에러 해결

### 성능 최적화
- **목록 제한**: `.slice(0, 4)`로 초기 렌더링 성능 확보
- **Pure Component**: props 변경 시에만 리렌더링
- **Utils 분리**: 비즈니스 로직과 UI 로직 분리로 테스트 용이성 향상

## 🧪 수동 테스트 가이드
### 📋 기능 테스트
1. **날짜 필터링**: 날짜 변경 시 해당 날짜 스케줄만 노출되는지 확인  
2. **역할별 액션**: fan/manager/favorites 역할별 우측 버튼 차이 확인
3. **아코디언 동작**: 클릭 시 상세 정보 자연스럽게 확장/축소
4. **빈 상태**: 스케줄 없는 날짜 선택 시 안내 메시지 표시

### 📱 반응형 테스트  
5. **브레이크포인트**: `sm(640px)`, `md(768px)` 기준 레이아웃 변화 확인
6. **터치 영역**: 모바일에서 아이콘 버튼 터치 용이성 확인
7. **텍스트 오버플로우**: 긴 제목/요약 텍스트 `truncate` 동작 확인

### ♿ 접근성 테스트
8. **키보드 네비게이션**: Tab으로 모든 인터랙티브 요소 접근 가능
9. **스크린 리더**: `aria-label`, `aria-expanded` 정상 읽기
10. **포커스 표시**: 버튼 포커스 시 `focus-visible:ring` 표시

## ✅ 체크리스트
- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.  
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.  
- [x] 실행에 문제가 없는지 테스트했습니다(모바일/데스크).  
- [x] **ESLint 규칙 준수**: Airbnb 설정 100% 통과 확인
- [x] **TypeScript 에러 없음**: 타입 안전성 확보
- [x] **인터랙티브 테스트 완료**: 실제 상태 변경 동작 확인
- [x] 이슈 브랜치 → develop 은 **squash and merge**, develop → main 은 **rebase and merge**를 선택했습니다.

## 🧩 기타 참고사항
### 🎨 디자인 조정사항
- **와이어프레임 vs 실제**: 모바일 사용성 향상을 위해 버튼 크기, 간격 등 Tailwind 반응형 가이드라인에 맞춰 조정
- **시각적 일관성**: fuchsia 컬러 테마로 전체 서비스와 톤앤매너 통일

### 🔧 기술적 특징
- **Props 기반 설계**: 완전한 재사용성, 페이지별 다른 데이터/핸들러 주입 가능
- **Utils 분리**: 날짜 처리, 필터링 로직 테스트 가능한 순수 함수로 분리
- **확장성**: `className` props로 사용처별 스타일 오버라이드 가능

### ⚠️ 주의사항
- **와이어프레임 vs 실제 구현**: 모바일 사용성 향상을 위해 버튼 크기, 간격 등 일부 조정
- Tailwind 반응형 브레이크포인트에 맞춰 최적화
- **API 연동**: 현재는 UI 컴포넌트만 구현, 데이터 fetching은 페이지 컴포넌트에서 처리 필요
- **높이 제어**: 필요시 사용처에서 `className="h-96"` 등으로 컨테이너 높이 제한 가능

## 📸 스크린샷
> 일반 유저 (팬) 유저 로그인 후 일정용 / 스케줄 없는 날짜
https://github.com/user-attachments/assets/8a966588-6bfa-4e2c-b5b9-c5ea23bc358a

> 마이페이지 - 즐겨찾기한 일정용 
<img width="780" height="667" alt="즐겨찾기_ui" src="https://github.com/user-attachments/assets/96b065d0-d070-4d01-abd5-a5372695971e" />

> 매니저 로그인 후 메인페이지용
<img width="812" height="714" alt="매니저ui" src="https://github.com/user-attachments/assets/a2e84572-1c68-4352-8346-26cfd7c8d7c0" />

>아이돌 로그인 후 메인페이지용
<img width="796" height="673" alt="아이돌UI" src="https://github.com/user-attachments/assets/8a396018-dd7b-4ee1-97ad-b837a4960459" />

> 일정 클릭시 상세보기 - 토글
<img width="857" height="834" alt="상세보기_토글" src="https://github.com/user-attachments/assets/f9a2201a-4778-4260-a49a-df3f462a5a4c" />

> 반응형 확인
https://github.com/user-attachments/assets/712da466-dbfe-41d8-a215-926a833df31b

### 🖥️ 데스크톱 (md 이상)
- 역할별 액션 버튼 차이 확인
- 아코디언 확장 시 자연스러운 레이아웃

### 📱 모바일 (sm 이하)  
- 터치 친화적 버튼 크기
- 좁은 화면에서도 가독성 확보

## 🔗 연관된 이슈
closes #26