### PR TITLE
Feat: 마이페이지 레이아웃 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,20 @@ import '@/App.css';
 import { Route, Routes } from 'react-router-dom';
 
 import Layout from '@/components/layouts/Layout';
+import MyPageLayout from '@/components/layouts/MyPageLayout';
 import Main from '@/pages/Main';
+import MyProfile from '@/pages/MyProfile';
+import MySchedule from '@/pages/MySchedule';
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
         <Route index element={<Main />} />
+      </Route>
+      <Route path="/mypage" element={<MyPageLayout />}>
+        <Route path="myprofile" element={<MyProfile />} />
+        <Route path="myschedule" element={<MySchedule />} />
       </Route>
     </Routes>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,18 @@
 import '@/App.css';
 
+import { Route, Routes } from 'react-router-dom';
+
+import Layout from './components/layouts/Layout';
+import Main from './pages/Main';
+
 function App() {
-  return <p>hello</p>;
+  return (
+    <Routes>
+      <Route path="/" element={<Layout />}>
+        <Route index element={<Main />} />
+      </Route>
+    </Routes>
+  );
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,8 @@ import '@/App.css';
 
 import { Route, Routes } from 'react-router-dom';
 
-import Layout from './components/layouts/Layout';
-import Main from './pages/Main';
+import Layout from '@/components/layouts/Layout';
+import Main from '@/pages/Main';
 
 function App() {
   return (

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
       variant: {
         primary:
           'border-2 border-transparent bg-fuchsia-400 text-white hover:bg-fuchsia-500',
-        secondary: 'border-2 border-transparent bg-gray-200 hover:bg-gray-300',
+        secondary: 'border-2 border-transparent bg-gray-100 hover:bg-gray-200',
         outline:
           'border-2 border-fuchsia-400 text-fuchsia-400 hover:bg-fuchsia-400 hover:text-white hover:border-fuchsia-400',
       },

--- a/src/components/common/header/DesktopMenu.tsx
+++ b/src/components/common/header/DesktopMenu.tsx
@@ -28,7 +28,7 @@ function DesktopMenu({
   };
 
   return (
-    <nav className="hidden items-center space-x-3 pr-10 md:flex">
+    <nav className="hidden items-center space-x-3 md:flex">
       {isLoggedIn ? (
         <UserDropdown
           userName={userName || '회원'}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -20,24 +20,26 @@ function Header({ isLoggedIn, userName, profileImageUrl }: HeaderProps) {
   const displayUserName = userName?.trim() || '회원';
 
   return (
-    <header className="fixed top-0 right-0 left-0 z-50 flex h-16 items-center justify-between border-b border-gray-300 bg-white pr-6">
-      <Link to="/" className="cursor-pointer pl-11 text-xl font-bold">
-        DingDing
-      </Link>
+    <header className="fixed top-0 right-0 left-0 z-50 h-16 border-b border-gray-300 bg-white px-6 md:px-10">
+      <div className="mx-auto flex h-full max-w-screen-xl items-center justify-between">
+        <Link to="/" className="cursor-pointer text-xl font-bold">
+          DingDing
+        </Link>
 
-      <DesktopMenu
-        isLoggedIn={isLoggedIn}
-        userName={displayUserName}
-        profileImageUrl={profileImageUrl}
-      />
+        <DesktopMenu
+          isLoggedIn={isLoggedIn}
+          userName={displayUserName}
+          profileImageUrl={profileImageUrl}
+        />
 
-      <MobileMenu
-        isLoggedIn={isLoggedIn}
-        userName={displayUserName}
-        isDropdownOpen={isMobileDropdownOpen}
-        onToggleDropdown={handleToggleMobileMenu}
-        profileImageUrl={profileImageUrl}
-      />
+        <MobileMenu
+          isLoggedIn={isLoggedIn}
+          userName={displayUserName}
+          isDropdownOpen={isMobileDropdownOpen}
+          onToggleDropdown={handleToggleMobileMenu}
+          profileImageUrl={profileImageUrl}
+        />
+      </div>
     </header>
   );
 }

--- a/src/components/common/header/MobileMenu.tsx
+++ b/src/components/common/header/MobileMenu.tsx
@@ -31,7 +31,11 @@ function MobileMenu({
   return (
     <>
       <div className="md:hidden">
-        <button type="button" onClick={onToggleDropdown} className="p-2">
+        <button
+          type="button"
+          onClick={onToggleDropdown}
+          className="cursor-pointer"
+        >
           {isLoggedIn ? (
             <UserIcon className="h-6 w-6 text-gray-800" />
           ) : (

--- a/src/components/common/header/MobileMenu.tsx
+++ b/src/components/common/header/MobileMenu.tsx
@@ -31,11 +31,7 @@ function MobileMenu({
   return (
     <>
       <div className="md:hidden">
-        <button
-          type="button"
-          onClick={onToggleDropdown}
-          className="cursor-pointer"
-        >
+        <button type="button" onClick={onToggleDropdown}>
           {isLoggedIn ? (
             <UserIcon className="h-6 w-6 text-gray-800" />
           ) : (

--- a/src/components/common/header/UserDropdown.tsx
+++ b/src/components/common/header/UserDropdown.tsx
@@ -72,14 +72,14 @@ function UserDropdown({
       <button
         type="button"
         onClick={onToggle}
-        className="mr-14 ml-auto flex h-9 w-9 items-center justify-center rounded-full transition hover:bg-gray-100"
+        className="mr-[-8px] flex cursor-pointer items-center justify-center rounded-full p-2 transition hover:bg-gray-100"
         aria-label="사용자 드롭다운 열기"
       >
         <UserIcon className="h-6 w-6 text-gray-700" />
       </button>
 
       {isOpen && (
-        <div className="fixed top-16 right-9 z-50 hidden w-52 border border-gray-200 bg-white p-4 shadow md:block">
+        <div className="absolute top-13 right-0 z-50 mr-[-6px] hidden w-52 border border-gray-200 bg-white p-4 shadow min-[1476px]:right-1/2 min-[1476px]:translate-x-1/2 md:block">
           {dropdownContent}
         </div>
       )}

--- a/src/components/common/header/UserDropdown.tsx
+++ b/src/components/common/header/UserDropdown.tsx
@@ -72,7 +72,7 @@ function UserDropdown({
       <button
         type="button"
         onClick={onToggle}
-        className="mr-[-8px] flex cursor-pointer items-center justify-center rounded-full p-2 transition hover:bg-gray-100"
+        className="mr-[-8px] flex items-center justify-center rounded-full p-2 transition hover:bg-gray-100"
         aria-label="사용자 드롭다운 열기"
       >
         <UserIcon className="h-6 w-6 text-gray-700" />

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -59,7 +59,7 @@ export default function Modal({
               onClick={onClose}
               aria-label="모달 닫기"
             >
-              <XMarkIcon className="w-5 cursor-pointer" />
+              <XMarkIcon className="w-5" />
             </button>
             <h2 className="my-2 text-xl font-semibold">{title}</h2>
             {children}

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
 
-import Footer from '../common/Footer';
-import { Header } from '../common/header';
+import Footer from '@/components/common/Footer';
+import { Header } from '@/components/common/header';
 
 export default function Layout() {
   return (

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from 'react-router-dom';
+
+import Footer from '../common/Footer';
+import { Header } from '../common/header';
+
+export default function Layout() {
+  return (
+    <>
+      <Header isLoggedIn={false} />
+      <main className="m-auto mt-16 max-w-screen-xl">
+        <Outlet />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/components/layouts/MyPageLayout.tsx
+++ b/src/components/layouts/MyPageLayout.tsx
@@ -1,0 +1,60 @@
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
+import clsx from 'clsx';
+import { Outlet, useLocation } from 'react-router-dom';
+
+import { Button } from '@/components/common/Button';
+import Footer from '@/components/common/Footer';
+import { Header } from '@/components/common/header';
+
+const MYPAGE_NAV = [
+  { label: '내 프로필', path: '/mypage/myprofile' },
+  { label: '즐겨찾기한 일정', path: '/mypage/myschedule' },
+];
+
+export default function MyPageLayout() {
+  const location = useLocation();
+
+  return (
+    <>
+      <Header isLoggedIn={false} />
+      <div className="m-auto mt-16 flex max-w-[1360px] px-6 md:px-10">
+        <aside className="w-55 pr-4">
+          <h2 className="py-10 text-3xl font-semibold">마이페이지</h2>
+
+          <nav className="items-strech flex flex-col pb-10">
+            {MYPAGE_NAV.map(({ label, path }) => {
+              const isActive = location.pathname === path;
+
+              return (
+                <Button
+                  variant="secondary"
+                  className={clsx(
+                    'flex w-full !justify-between py-4',
+                    isActive ? 'bg-gray-100 font-semibold' : 'bg-white',
+                  )}
+                >
+                  <p>{label}</p>
+                  <ChevronRightIcon className="w-5" />
+                </Button>
+              );
+            })}
+          </nav>
+
+          <div className="flex flex-col items-start gap-2 border-t-1 border-gray-200 py-10 text-sm">
+            <button type="button" className="px-4 py-2">
+              <p className="hover:underline">로그아웃</p>
+            </button>
+            <button type="button" className="px-4 py-2">
+              <p className="hover:underline">회원 탈퇴</p>
+            </button>
+          </div>
+        </aside>
+
+        <main>
+          <Outlet />
+        </main>
+      </div>
+      <Footer />
+    </>
+  );
+}

--- a/src/components/layouts/MyPageLayout.tsx
+++ b/src/components/layouts/MyPageLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet } from 'react-router-dom';
 import Footer from '@/components/common/Footer';
 import { Header } from '@/components/common/header';
 import Nav from '@/components/mypage/Nav';
+import BottomNav from '@/components/mypage/BottomNav';
 
 export default function MyPageLayout() {
   return (
@@ -13,15 +14,7 @@ export default function MyPageLayout() {
           <h2 className="py-10 text-3xl font-semibold">마이페이지</h2>
 
           <Nav />
-
-          <div className="flex flex-col items-start gap-2 border-t-1 border-gray-200 py-10 text-sm">
-            <button type="button" className="px-4 py-2">
-              <p className="hover:underline">로그아웃</p>
-            </button>
-            <button type="button" className="px-4 py-2">
-              <p className="hover:underline">회원 탈퇴</p>
-            </button>
-          </div>
+          <BottomNav />
         </aside>
 
         <main>

--- a/src/components/layouts/MyPageLayout.tsx
+++ b/src/components/layouts/MyPageLayout.tsx
@@ -9,18 +9,22 @@ export default function MyPageLayout() {
   return (
     <>
       <Header isLoggedIn={false} />
-      <div className="m-auto mt-16 flex max-w-[1360px] items-stretch px-6 md:px-10">
-        <aside className="flex w-55 flex-col justify-between pr-4">
+      <div className="m-auto mt-16 flex max-w-[1360px] flex-col items-center px-6 md:flex-row md:items-stretch md:px-10">
+        <aside className="hidden w-55 flex-col justify-between pr-4 md:flex">
           <div>
             <h2 className="py-10 text-3xl font-semibold">마이페이지</h2>
             <Nav />
           </div>
-          <BottomNav />
+          <BottomNav className="hidden md:flex" />
         </aside>
+
+        <Nav className="md:hidden" />
 
         <main className="flex-1">
           <Outlet />
         </main>
+
+        <BottomNav className="flex md:hidden" />
       </div>
       <Footer />
     </>

--- a/src/components/layouts/MyPageLayout.tsx
+++ b/src/components/layouts/MyPageLayout.tsx
@@ -2,22 +2,23 @@ import { Outlet } from 'react-router-dom';
 
 import Footer from '@/components/common/Footer';
 import { Header } from '@/components/common/header';
-import Nav from '@/components/mypage/Nav';
 import BottomNav from '@/components/mypage/BottomNav';
+import Nav from '@/components/mypage/Nav';
 
 export default function MyPageLayout() {
   return (
     <>
       <Header isLoggedIn={false} />
-      <div className="m-auto mt-16 flex max-w-[1360px] px-6 md:px-10">
-        <aside className="w-55 pr-4">
-          <h2 className="py-10 text-3xl font-semibold">마이페이지</h2>
-
-          <Nav />
+      <div className="m-auto mt-16 flex max-w-[1360px] items-stretch px-6 md:px-10">
+        <aside className="flex w-55 flex-col justify-between pr-4">
+          <div>
+            <h2 className="py-10 text-3xl font-semibold">마이페이지</h2>
+            <Nav />
+          </div>
           <BottomNav />
         </aside>
 
-        <main>
+        <main className="flex-1">
           <Outlet />
         </main>
       </div>

--- a/src/components/layouts/MyPageLayout.tsx
+++ b/src/components/layouts/MyPageLayout.tsx
@@ -1,19 +1,10 @@
-import { ChevronRightIcon } from '@heroicons/react/24/outline';
-import clsx from 'clsx';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
-import { Button } from '@/components/common/Button';
 import Footer from '@/components/common/Footer';
 import { Header } from '@/components/common/header';
-
-const MYPAGE_NAV = [
-  { label: '내 프로필', path: '/mypage/myprofile' },
-  { label: '즐겨찾기한 일정', path: '/mypage/myschedule' },
-];
+import Nav from '@/components/mypage/Nav';
 
 export default function MyPageLayout() {
-  const location = useLocation();
-
   return (
     <>
       <Header isLoggedIn={false} />
@@ -21,24 +12,7 @@ export default function MyPageLayout() {
         <aside className="w-55 pr-4">
           <h2 className="py-10 text-3xl font-semibold">마이페이지</h2>
 
-          <nav className="items-strech flex flex-col pb-10">
-            {MYPAGE_NAV.map(({ label, path }) => {
-              const isActive = location.pathname === path;
-
-              return (
-                <Button
-                  variant="secondary"
-                  className={clsx(
-                    'flex w-full !justify-between py-4',
-                    isActive ? 'bg-gray-100 font-semibold' : 'bg-white',
-                  )}
-                >
-                  <p>{label}</p>
-                  <ChevronRightIcon className="w-5" />
-                </Button>
-              );
-            })}
-          </nav>
+          <Nav />
 
           <div className="flex flex-col items-start gap-2 border-t-1 border-gray-200 py-10 text-sm">
             <button type="button" className="px-4 py-2">

--- a/src/components/mypage/BottomNav.tsx
+++ b/src/components/mypage/BottomNav.tsx
@@ -1,10 +1,17 @@
+import clsx from 'clsx';
+
 const MYPAGE_BOTTOM_NAV = ['로그아웃', '회원 탈퇴'];
 
-export default function BottomNav() {
+export default function BottomNav({ className }: { className: string }) {
   return (
-    <div className="flex flex-col items-start gap-2 border-t-1 border-gray-200 py-10 text-sm">
+    <div
+      className={clsx(
+        'flex-col items-center gap-3 border-t-1 border-gray-200 py-10 text-xs md:items-start md:gap-6 md:text-sm',
+        className,
+      )}
+    >
       {MYPAGE_BOTTOM_NAV.map(el => (
-        <button type="button" className="px-4 py-2">
+        <button type="button" className="mx-4">
           <p className="hover:underline">{el}</p>
         </button>
       ))}

--- a/src/components/mypage/BottomNav.tsx
+++ b/src/components/mypage/BottomNav.tsx
@@ -2,11 +2,11 @@ import clsx from 'clsx';
 
 const MYPAGE_BOTTOM_NAV = ['로그아웃', '회원 탈퇴'];
 
-export default function BottomNav({ className }: { className: string }) {
+export default function BottomNav({ className }: { className?: string }) {
   return (
     <div
       className={clsx(
-        'flex-col items-center gap-3 border-t-1 border-gray-200 py-10 text-xs md:items-start md:gap-6 md:text-sm',
+        'flex-col items-center gap-3 border-gray-200 py-10 text-xs md:items-start md:gap-6 md:border-t-1 md:text-sm',
         className,
       )}
     >

--- a/src/components/mypage/BottomNav.tsx
+++ b/src/components/mypage/BottomNav.tsx
@@ -1,0 +1,13 @@
+const MYPAGE_BOTTOM_NAV = ['로그아웃', '회원 탈퇴'];
+
+export default function BottomNav() {
+  return (
+    <div className="flex flex-col items-start gap-2 border-t-1 border-gray-200 py-10 text-sm">
+      {MYPAGE_BOTTOM_NAV.map(el => (
+        <button type="button" className="px-4 py-2">
+          <p className="hover:underline">{el}</p>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/mypage/Nav.tsx
+++ b/src/components/mypage/Nav.tsx
@@ -1,0 +1,35 @@
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
+import clsx from 'clsx';
+import { useLocation } from 'react-router-dom';
+
+import { Button } from '@/components/common/Button';
+
+const MYPAGE_NAV = [
+  { label: '내 프로필', path: '/mypage/myprofile' },
+  { label: '즐겨찾기한 일정', path: '/mypage/myschedule' },
+];
+
+export default function Nav() {
+  const location = useLocation();
+
+  return (
+    <nav className="items-strech flex flex-col pb-10">
+      {MYPAGE_NAV.map(({ label, path }) => {
+        const isActive = location.pathname === path;
+
+        return (
+          <Button
+            variant="secondary"
+            className={clsx(
+              'flex w-full !justify-between py-4',
+              isActive ? 'bg-gray-100 font-semibold' : 'bg-white',
+            )}
+          >
+            <p>{label}</p>
+            <ChevronRightIcon className="w-5" />
+          </Button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/mypage/Nav.tsx
+++ b/src/components/mypage/Nav.tsx
@@ -2,14 +2,14 @@ import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { Button } from '@/components/common/Button';
-
 const MYPAGE_NAV = [
   { label: '내 프로필', path: '/mypage/myprofile' },
   { label: '즐겨찾기한 일정', path: '/mypage/myschedule' },
 ];
+const DesktopButtonStyle =
+  'md:inline-flex md:justify-between md:border-none md:w-auto md:rounded-md md:px-4 md:py-4 md:transition-colors md:hover:bg-gray-200';
 
-export default function Nav() {
+export default function Nav({ className }: { className?: string }) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -18,22 +18,30 @@ export default function Nav() {
   };
 
   return (
-    <nav className="items-strech flex flex-col pb-10">
+    <nav
+      className={clsx(
+        'items-strech flex w-full md:w-auto md:flex-col md:pb-10',
+        className,
+      )}
+    >
       {MYPAGE_NAV.map(({ label, path }) => {
         const isActive = location.pathname === path;
 
         return (
-          <Button
-            variant="secondary"
+          <button
             className={clsx(
-              'flex w-full !justify-between py-4',
-              isActive ? 'bg-gray-100 font-semibold' : 'bg-white',
+              'w-1/2 border-b-2 py-4',
+              DesktopButtonStyle,
+              isActive
+                ? 'border-gray-700 font-semibold md:bg-gray-100 md:font-semibold'
+                : 'border-gray-200 md:bg-white',
             )}
+            type="button"
             onClick={() => handleClickButton(path)}
           >
             <p>{label}</p>
-            <ChevronRightIcon className="w-5" />
-          </Button>
+            <ChevronRightIcon className="hidden w-5 md:block" />
+          </button>
         );
       })}
     </nav>

--- a/src/components/mypage/Nav.tsx
+++ b/src/components/mypage/Nav.tsx
@@ -1,6 +1,6 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/common/Button';
 
@@ -11,6 +11,11 @@ const MYPAGE_NAV = [
 
 export default function Nav() {
   const location = useLocation();
+  const navigate = useNavigate();
+
+  const handleClickButton = (path: string) => {
+    navigate(path);
+  };
 
   return (
     <nav className="items-strech flex flex-col pb-10">
@@ -24,6 +29,7 @@ export default function Nav() {
               'flex w-full !justify-between py-4',
               isActive ? 'bg-gray-100 font-semibold' : 'bg-white',
             )}
+            onClick={() => handleClickButton(path)}
           >
             <p>{label}</p>
             <ChevronRightIcon className="w-5" />

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,5 @@
 @import 'tailwindcss';
+
+button {
+  cursor: pointer;
+}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,0 +1,3 @@
+export default function Main() {
+  return <>메인페이지입니다.</>;
+}

--- a/src/pages/MyProfile.tsx
+++ b/src/pages/MyProfile.tsx
@@ -1,0 +1,3 @@
+export default function MyProfile() {
+  return <div>내 프로필</div>;
+}

--- a/src/pages/MySchedule.tsx
+++ b/src/pages/MySchedule.tsx
@@ -1,0 +1,3 @@
+export default function MySchedule() {
+  return <div>즐겨찾기한 일정</div>;
+}


### PR DESCRIPTION
## 🚀 PR 요약

마이페이지 레이아웃 컴포넌트를 반응형으로 제작

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항


https://github.com/user-attachments/assets/e939d5b5-e31d-4e58-878e-04ccc1abc580

pc버전과 모바일버전을 따로 나누지 않고 한 파일 내에서 작성하려다보니 MyPageLayout 컴포넌트에서 Nav와 BottomNav이 중복 사용되었습니다. 추후에 useMediaQuery를 사용하는 방식으로 리팩토링하겠습니다.

## 🔗 연관된 이슈

> closes #40
