### PR TITLE
Feat: 마이페이지 내 프로필 섹션 컴포넌트 추가

### DIFF
--- a/src/components/layouts/MyPageLayout.tsx
+++ b/src/components/layouts/MyPageLayout.tsx
@@ -20,7 +20,7 @@ export default function MyPageLayout() {
 
         <Nav className="md:hidden" />
 
-        <main className="flex-1">
+        <main className="w-full flex-1">
           <Outlet />
         </main>
 

--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@/components/common/Button';
+import { UserAvatarImage } from '@/components/common/UserAvatarImage';
+
+export default function Profile() {
+  return (
+    <section className="my-6 flex items-center justify-between gap-6 rounded-3xl border-2 border-gray-200 p-6 md:my-25 md:flex-col md:border-none">
+      <div className="flex items-center gap-6 md:flex-col">
+        <div className="block grid items-center sm:hidden">
+          <UserAvatarImage avatarSize="md" />
+        </div>
+        <div className="hidden sm:block md:hidden">
+          <UserAvatarImage avatarSize="xl" />
+        </div>
+        <div className="hidden md:block">
+          <UserAvatarImage avatarSize="2xl" />
+        </div>
+
+        <div>
+          <p className="text-xs text-gray-500 sm:text-sm md:text-3xl md:text-black">
+            안녕하세요, ooo님!
+          </p>
+          <p className="text-xl font-semibold md:hidden">(닉네임)</p>
+        </div>
+        <p className="hidden text-xs text-gray-500 md:block">
+          가입일자: yyyy/mm/dd
+        </p>
+      </div>
+
+      <div className="block sm:hidden">
+        <Button shape="pill" variant="secondary" size="sm">
+          프로필 수정
+        </Button>
+      </div>
+      <div className="hidden sm:block">
+        <Button shape="pill" variant="secondary" size="md">
+          프로필 수정
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/MyProfile.tsx
+++ b/src/pages/MyProfile.tsx
@@ -1,3 +1,5 @@
+import Profile from '@/components/mypage/Profile';
+
 export default function MyProfile() {
-  return <div>내 프로필</div>;
+  return <Profile />;
 }


### PR DESCRIPTION
## 🚀 PR 요약

마이페이지에 들어갈 내 프로필 섹션 컴포넌트 제작 (Profile.tsx)

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

모바일 화면일 때의 ui를 조금 변경하였습니다.
(기존: 프로필, 닉네임 각각 수정 버튼 -> pc 버전과 동일하게 '프로필 수정' 버튼만 둠)

<img width="1914" height="905" alt="image" src="https://github.com/user-attachments/assets/c2895212-49be-4e1c-a38c-f71dda71ee7a" />

<img width="350"  alt="KakaoTalk_20250814_003842325" src="https://github.com/user-attachments/assets/ac458c3a-6344-4398-b79e-f00e210c1d94" />

ui 수정할 부분 있으면 말씀해주세요!

## 🔗 연관된 이슈

> closes #41 
