### PR TITLE
Refactor: 공통 Layout 컴포넌트 리팩토링

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,13 +1,31 @@
+import { cva } from 'class-variance-authority';
+import clsx from 'clsx';
 import { Outlet } from 'react-router-dom';
 
 import Footer from '../common/Footer';
 import { Header } from '../common/header';
 
-export default function Layout() {
+const layoutStyle = cva('m-auto mt-16', {
+  variants: {
+    component: {
+      default: 'max-w-screen-xl',
+      landing: '',
+    },
+  },
+  defaultVariants: {
+    component: 'default',
+  },
+});
+
+interface LayoutProps {
+  component?: 'default' | 'landing';
+}
+
+export default function Layout({ component }: LayoutProps) {
   return (
     <>
       <Header isLoggedIn={false} />
-      <main className="m-auto mt-16 max-w-screen-xl">
+      <main className={clsx(layoutStyle({ component }))}>
         <Outlet />
       </main>
       <Footer />


### PR DESCRIPTION
## 🚀 PR 요약

공통 Layout 컴포넌트 리팩토링

- `<LandingPage />` 전용 스타일과 나머지 컴포넌트용 스타일을 cva로 구분
- props를 받아와 clsx로 스타일 적용

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

기존 Layout 컴포넌트에 cva로 스타일만 간단하게 구분 시켜줬습니다.
defaultVariants로 `'max-w-screen-xl'`가 적용된 스타일을 지정했습니다.
랜딩 페이지가 아닌 다른 페이지들은 props 추가하실 필요 없이 기존 방법대로 사용하시면 됩니다!

## 🔗 연관된 이슈

> closes #62
