### PR TITLE
Feat: Hero 섹션 컴포넌트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,13 @@ import '@/App.css';
 import { Route, Routes } from 'react-router-dom';
 
 import Layout from './components/layouts/Layout';
-import Main from './pages/Main';
+import LandingPage from './pages/landing/LandingPage';
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
-        <Route index element={<Main />} />
+        <Route index element={<LandingPage />} />
       </Route>
     </Routes>
   );

--- a/src/pages/landing/sections/Hero.tsx
+++ b/src/pages/landing/sections/Hero.tsx
@@ -1,7 +1,29 @@
+import clsx from 'clsx';
+
+import { Button } from '@/components/common/Button';
+
+const heroPositionStyle = 'mx-[calc(50%-50vw)]';
+const heroBackgroundStyle =
+  'bg-[url(@/assets/images/placeholder-lg.jpg)] bg-cover bg-center bg-no-repeat';
+
 function Hero() {
   return (
-    <div>
-      <span>Hero</span>
+    <div className={clsx(heroPositionStyle, heroBackgroundStyle)}>
+      <div className="flex flex-col items-center gap-8 bg-white/15 px-[2.5%] py-24 text-white md:p-24">
+        <h1 className="flex flex-col gap-4 text-center text-4xl font-bold tracking-tight break-keep sm:text-5xl xl:flex-row xl:gap-0">
+          <span className="hidden xl:block">최애 아이돌의 스케줄,&nbsp;</span>
+          <span className="block xl:hidden">최애 아이돌의 스케줄</span>
+          <span>딩딩이 알려드릴게요</span>
+        </h1>
+        <div className="text-center text-sm/7 font-medium sm:text-base/7">
+          <p>최애 아이돌의 스케줄이 궁금하신가요?</p>
+          <p>딩딩이 최애 아이돌의 공개 스케줄을 미리 알아보고</p>
+          <p>놓치지 않도록 알림으로 알려드릴게요.</p>
+        </div>
+        <Button variant="primary" size="lg" shape="pill">
+          시작하기
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/pages/landing/sections/Hero.tsx
+++ b/src/pages/landing/sections/Hero.tsx
@@ -1,11 +1,6 @@
-import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/common/Button';
-
-const heroPositionStyle = 'mx-[calc(50%-50vw)]';
-const heroBackgroundStyle =
-  'bg-[url(@/assets/images/placeholder-lg.jpg)] bg-cover bg-center bg-no-repeat';
 
 function Hero() {
   const navigate = useNavigate();
@@ -13,7 +8,7 @@ function Hero() {
   const handleClick = () => navigate('/login');
 
   return (
-    <div className={clsx(heroPositionStyle, heroBackgroundStyle)}>
+    <div className="bg-[url(@/assets/images/placeholder-lg.jpg)] bg-cover bg-center bg-no-repeat">
       <div className="flex flex-col items-center gap-8 bg-white/15 px-[2.5%] py-24 text-white md:p-24">
         <h1 className="flex flex-col gap-4 text-center text-4xl font-bold tracking-tight break-keep sm:text-5xl xl:flex-row xl:gap-0">
           <span className="hidden xl:block">최애 아이돌의 스케줄,&nbsp;</span>

--- a/src/pages/landing/sections/Hero.tsx
+++ b/src/pages/landing/sections/Hero.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/common/Button';
 
@@ -7,6 +8,10 @@ const heroBackgroundStyle =
   'bg-[url(@/assets/images/placeholder-lg.jpg)] bg-cover bg-center bg-no-repeat';
 
 function Hero() {
+  const navigate = useNavigate();
+
+  const handleClick = () => navigate('/login');
+
   return (
     <div className={clsx(heroPositionStyle, heroBackgroundStyle)}>
       <div className="flex flex-col items-center gap-8 bg-white/15 px-[2.5%] py-24 text-white md:p-24">
@@ -20,7 +25,7 @@ function Hero() {
           <p>딩딩이 최애 아이돌의 공개 스케줄을 미리 알아보고</p>
           <p>놓치지 않도록 알림으로 알려드릴게요.</p>
         </div>
-        <Button variant="primary" size="lg" shape="pill">
+        <Button variant="primary" size="lg" shape="pill" onClick={handleClick}>
           시작하기
         </Button>
       </div>


### PR DESCRIPTION
## 🚀 PR 요약

랜딩 페이지에 접근하자마자 보이는 Hero 섹션 컴포넌트 추가

## ✏️ 변경 유형

- [x]  feat: 새로운 기능 추가

## ✅ 체크리스트

- [x]  커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x]  커밋에 관련된 이슈 번호를 포함했습니다.
- [x]  실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

#### 히어로 섹션이란?

웹사이트에 접속하자마자 가장 먼저 보게 되는 부분으로, 보통 페이지 최상단에 위치
(참고 블로그 글 : [히어로 섹션이란?](https://itvc.tistory.com/entry/%ED%9E%88%EC%96%B4%EB%A1%9C-%EC%84%B9%EC%85%98Hero-Section%EC%9D%B4%EB%9E%80))

#### UI 및 레이아웃은 다음과 같습니다.

<div align='center'>
  <h4>1280px 이상 레이아웃</h4>
  <img src='https://github.com/user-attachments/assets/04b59a3a-e63c-40fb-8796-7135d47df25d' alt='1280px 이상 레이아웃' />
  <h4>1280px 미만 레이아웃</h4>
  <img src='https://github.com/user-attachments/assets/af1d41ed-040f-4383-8d28-ee8c06a6e840' alt='1280px 미만 레이아웃' />
  <h4>모바일 레이아웃</h4>
  <img src='https://github.com/user-attachments/assets/ff2d8a3e-de95-40b8-84ad-ebd2fe310192' alt='모바일 레이아웃' />
</div>


## 🔗 연관된 이슈

> closes #56
