### PR TITLE
Refactor: 드래그 스크롤 이벤트 조건부 적용

### DIFF
--- a/src/components/mypage/FavoriteIdols.tsx
+++ b/src/components/mypage/FavoriteIdols.tsx
@@ -2,7 +2,9 @@ import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
 
 import Card from '@/components/common/card';
+import { mediaQuery } from '@/constants/breakpoints';
 import { useDraggable } from '@/hooks/useDraggable';
+import useMediaQuery from '@/hooks/useMediaQuery';
 
 type Idol = {
   id: number;
@@ -13,6 +15,7 @@ type Idol = {
 };
 
 export default function FavoriteIdols() {
+  const isDesktop = useMediaQuery(mediaQuery.tablet);
   const containerRef = useRef<HTMLDivElement>(null);
   const events = useDraggable(containerRef);
 
@@ -38,7 +41,7 @@ export default function FavoriteIdols() {
       <div
         className="flex w-full flex-col flex-wrap items-center gap-4 md:flex-row md:flex-nowrap md:overflow-x-scroll"
         ref={containerRef}
-        {...events}
+        {...(isDesktop ? events : '')}
       >
         {idols.map(idol => (
           <Card


### PR DESCRIPTION
## 🚀 PR 요약

테블릿 사이즈 이상일 때만 드래그 스크롤 이벤트가 적용되도록 수정

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

### 적용 전) 
드래그 스크롤 이벤트가 필요없는 모바일 뷰에서도 이벤트 리스너가 적용됨

https://github.com/user-attachments/assets/2040d694-1d4c-434b-bf7c-15f7bec88ac3

### 적용 후)

https://github.com/user-attachments/assets/5e09d721-8fa3-4cde-b43f-b895134cd138




## 🔗 연관된 이슈

> closes #76 
