### PR TITLE
Feat: Chat 기본 구조 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import '@/App.css';
 import { Route, Routes } from 'react-router-dom';
 
 import Layout from './components/layouts/Layout';
+import Chat from './pages/chat/Chat';
 import LandingPage from './pages/landing/LandingPage';
 
 function App() {
@@ -10,6 +11,9 @@ function App() {
     <Routes>
       <Route path="/" element={<Layout component="landing" />}>
         <Route index element={<LandingPage />} />
+      </Route>
+      <Route path="/chat" element={<Layout component="chat" />}>
+        <Route index element={<Chat />} />
       </Route>
     </Routes>
   );

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+import { useState } from 'react';
+
+import ChatComposer from './sections/ChatComposer';
+import ChatConversationList from './sections/ChatConversationList';
+import ChatMessageList from './sections/ChatMessageList';
+
+function Chat() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleToggleConversationList = () => {
+    setIsVisible(prev => !prev);
+  };
+
+  return (
+    <div className="relative flex h-[calc(100dvh-64px)]">
+      <aside
+        className={clsx(
+          'h-full flex-1 lg:block',
+          isVisible ? 'absolute z-10 block w-full' : 'hidden',
+        )}
+      >
+        <ChatConversationList onToggleList={handleToggleConversationList} />
+      </aside>
+      <article className="relative flex flex-3 flex-col gap-4 px-4">
+        <section className="flex-1">
+          <ChatMessageList />
+        </section>
+        <section>
+          <ChatComposer onToggleList={handleToggleConversationList} />
+        </section>
+      </article>
+    </div>
+  );
+}
+
+export default Chat;

--- a/src/pages/chat/sections/ChatComposer.tsx
+++ b/src/pages/chat/sections/ChatComposer.tsx
@@ -1,0 +1,20 @@
+interface ChatComposerProps {
+  onToggleList: () => void;
+}
+
+function ChatComposer({ onToggleList }: ChatComposerProps) {
+  return (
+    <div className="flex justify-between bg-green-300">
+      <span>ChatComposer</span>
+      <button
+        type="button"
+        className="block bg-green-500 lg:hidden"
+        onClick={onToggleList}
+      >
+        대화 상대
+      </button>
+    </div>
+  );
+}
+
+export default ChatComposer;

--- a/src/pages/chat/sections/ChatConversationList.tsx
+++ b/src/pages/chat/sections/ChatConversationList.tsx
@@ -1,0 +1,20 @@
+interface ChatConversationListProps {
+  onToggleList: () => void;
+}
+
+function ChatConversationList({ onToggleList }: ChatConversationListProps) {
+  return (
+    <div className="h-full bg-blue-300">
+      <span>ChatConversationList</span>
+      <button
+        type="button"
+        className="block bg-blue-500 lg:hidden"
+        onClick={onToggleList}
+      >
+        닫기
+      </button>
+    </div>
+  );
+}
+
+export default ChatConversationList;

--- a/src/pages/chat/sections/ChatMessageList.tsx
+++ b/src/pages/chat/sections/ChatMessageList.tsx
@@ -1,0 +1,9 @@
+function ChatMessageList() {
+  return (
+    <div className="h-full bg-pink-300">
+      <span>ChatMessageList</span>
+    </div>
+  );
+}
+
+export default ChatMessageList;


### PR DESCRIPTION
## 🚀 PR 요약

- Chat.tsx, ChatMessageList.tsx, ChatComposer.tsx, ChatConversationList.tsx 생성 및 기본 구조 추가
- App.tsx에 `/chat` 라우트 추가

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

각 컴포넌트의 상세 요소 추가 전 채팅 페이지 와이어프레임에 맞게 기본 구조를 잡았습니다.
반응형 레이아웃을 고려하여 1024px를 기준으로 대화 상대 목록(ChatConversationList.tsx)의 배치를 다르게 했습니다.

- 1024px 이상 : 화면 왼쪽에 사이드바 형태로 배치
<div align='center'>
  <img width="1920" alt="image" src="https://github.com/user-attachments/assets/f9af563a-b48b-4ade-9c9e-f923682686c9" />
</div>

- 1024px 미만 : ChatComposer 컴포넌트 내의 버튼 클릭 시 전체 화면에 활성화 (페이지 X)
<div align='center'>
  <img width="299" alt="image" src="https://github.com/user-attachments/assets/a9f7b678-909e-49a3-8e4c-d7a615feb68d" />
  <img width="298" alt="image" src="https://github.com/user-attachments/assets/e6f33b2f-e1f7-44bb-b018-10e25767b5b1" />
</div>


## 🔗 연관된 이슈

> closes #83 
