### PR TITLE
Feat: user 전역 상태 생성 및 적용

### DIFF
--- a/src/components/common/header/DesktopMenu.tsx
+++ b/src/components/common/header/DesktopMenu.tsx
@@ -2,20 +2,12 @@ import { useState } from 'react';
 
 import { Button } from '@/components/common/Button';
 import { usePageNav } from '@/hooks/usePageNav';
+import { useUserStore } from '@/stores/userStore';
 
 import UserDropdown from './UserDropdown';
 
-type DesktopMenuProps = {
-  isLoggedIn: boolean;
-  userName?: string;
-  profileImageUrl?: string;
-};
-
-function DesktopMenu({
-  isLoggedIn,
-  userName,
-  profileImageUrl,
-}: DesktopMenuProps) {
+function DesktopMenu() {
+  const { isLoggedIn } = useUserStore();
   const { navigateToLogin, navigateToSignup } = usePageNav();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -25,11 +17,9 @@ function DesktopMenu({
     <nav className="hidden items-center space-x-3 md:flex">
       {isLoggedIn ? (
         <UserDropdown
-          userName={userName || '회원'}
           isOpen={isDropdownOpen}
           onToggle={handleToggleDropdown}
           isMobile={false}
-          profileImageUrl={profileImageUrl}
         />
       ) : (
         <>

--- a/src/components/common/header/MobileMenu.tsx
+++ b/src/components/common/header/MobileMenu.tsx
@@ -1,24 +1,17 @@
 import { Bars3Icon, UserIcon } from '@heroicons/react/24/outline';
 
 import { usePageNav } from '@/hooks/usePageNav';
+import { useUserStore } from '@/stores/userStore';
 
 import UserDropdown from './UserDropdown';
 
 type MobileMenuProps = {
-  isLoggedIn: boolean;
-  userName?: string;
   isDropdownOpen: boolean;
   onToggleDropdown: () => void;
-  profileImageUrl?: string;
 };
 
-function MobileMenu({
-  isLoggedIn,
-  userName,
-  isDropdownOpen,
-  onToggleDropdown,
-  profileImageUrl,
-}: MobileMenuProps) {
+function MobileMenu({ isDropdownOpen, onToggleDropdown }: MobileMenuProps) {
+  const { isLoggedIn } = useUserStore();
   const dropdownButtonClass =
     'w-full pl-2 py-2 text-base text-left font-semibold text-gray-700 hover:font-bold hover:text-fuchsia-500';
 
@@ -44,13 +37,7 @@ function MobileMenu({
       {isDropdownOpen && (
         <div className="absolute top-16 right-0 z-50 w-52 border border-gray-200 bg-white p-4 shadow md:hidden">
           {isLoggedIn ? (
-            <UserDropdown
-              userName={userName || '회원'}
-              isOpen
-              onToggle={() => {}}
-              isMobile
-              profileImageUrl={profileImageUrl}
-            />
+            <UserDropdown isOpen onToggle={() => {}} isMobile />
           ) : (
             <div className="w-full py-1">
               <button

--- a/src/components/common/header/UserDropdown.tsx
+++ b/src/components/common/header/UserDropdown.tsx
@@ -2,6 +2,7 @@ import { UserIcon } from '@heroicons/react/24/outline';
 
 import { UserAvatarImage } from '@/components/common/UserAvatarImage';
 import { useUserStore } from '@/stores/userStore';
+import { usePageNav } from '@/hooks/usePageNav';
 
 type UserDropdownProps = {
   isOpen: boolean;
@@ -15,9 +16,7 @@ function UserDropdown({ isOpen, onToggle, isMobile }: UserDropdownProps) {
   const dropdownItemClass =
     'w-full pl-2 py-2 text-base text-left font-semibold text-gray-700 hover:font-bold hover:text-fuchsia-500';
 
-  const handleMyPage = () => {
-    // TODO: 마이페이지 라우팅 구현
-  };
+  const { navigateToMypage } = usePageNav();
 
   const handleLogout = () => {
     // TODO: 로그아웃 처리 구현
@@ -37,7 +36,7 @@ function UserDropdown({ isOpen, onToggle, isMobile }: UserDropdownProps) {
 
       <button
         type="button"
-        onClick={handleMyPage}
+        onClick={navigateToMypage}
         className={dropdownItemClass}
       >
         마이페이지

--- a/src/components/common/header/UserDropdown.tsx
+++ b/src/components/common/header/UserDropdown.tsx
@@ -1,8 +1,9 @@
 import { UserIcon } from '@heroicons/react/24/outline';
 
 import { UserAvatarImage } from '@/components/common/UserAvatarImage';
-import { useUserStore } from '@/stores/userStore';
+import { useLogout } from '@/hooks/useLogout';
 import { usePageNav } from '@/hooks/usePageNav';
+import { useUserStore } from '@/stores/userStore';
 
 type UserDropdownProps = {
   isOpen: boolean;
@@ -12,15 +13,12 @@ type UserDropdownProps = {
 
 function UserDropdown({ isOpen, onToggle, isMobile }: UserDropdownProps) {
   const { user } = useUserStore();
+  const { navigateToMypage } = usePageNav();
+  const { handleLogout } = useLogout();
+
   const userGreetingClass = 'text-base font-medium text-gray-600 my-4';
   const dropdownItemClass =
     'w-full pl-2 py-2 text-base text-left font-semibold text-gray-700 hover:font-bold hover:text-fuchsia-500';
-
-  const { navigateToMypage } = usePageNav();
-
-  const handleLogout = () => {
-    // TODO: 로그아웃 처리 구현
-  };
 
   const dropdownContent = (
     <div className="w-full py-1">

--- a/src/components/common/header/UserDropdown.tsx
+++ b/src/components/common/header/UserDropdown.tsx
@@ -1,22 +1,16 @@
 import { UserIcon } from '@heroicons/react/24/outline';
 
 import { UserAvatarImage } from '@/components/common/UserAvatarImage';
+import { useUserStore } from '@/stores/userStore';
 
 type UserDropdownProps = {
-  userName?: string;
   isOpen: boolean;
   onToggle: () => void;
   isMobile: boolean;
-  profileImageUrl?: string;
 };
 
-function UserDropdown({
-  userName,
-  isOpen,
-  onToggle,
-  isMobile,
-  profileImageUrl,
-}: UserDropdownProps) {
+function UserDropdown({ isOpen, onToggle, isMobile }: UserDropdownProps) {
+  const { user } = useUserStore();
   const userGreetingClass = 'text-base font-medium text-gray-600 my-4';
   const dropdownItemClass =
     'w-full pl-2 py-2 text-base text-left font-semibold text-gray-700 hover:font-bold hover:text-fuchsia-500';
@@ -33,14 +27,12 @@ function UserDropdown({
     <div className="w-full py-1">
       <div className="mb-7 flex flex-col items-center">
         <UserAvatarImage
-          profileImageUrl={profileImageUrl}
+          profileImageUrl={user?.profile_image_url}
           altText="사용자 프로필 이미지"
           avatarSize="xl"
           className="shadow-sm"
         />
-        <div className={userGreetingClass}>
-          {userName?.trim() || '회원'}님, 환영합니다
-        </div>
+        <div className={userGreetingClass}>{user?.nickname}님, 환영합니다</div>
       </div>
 
       <button

--- a/src/components/mypage/BottomNav.tsx
+++ b/src/components/mypage/BottomNav.tsx
@@ -1,8 +1,9 @@
+import { useLogout } from '@/hooks/useLogout';
 import clsx from 'clsx';
 
-const MYPAGE_BOTTOM_NAV = ['로그아웃', '회원 탈퇴'];
-
 export default function BottomNav({ className }: { className?: string }) {
+  const { handleLogout } = useLogout();
+
   return (
     <div
       className={clsx(
@@ -10,11 +11,12 @@ export default function BottomNav({ className }: { className?: string }) {
         className,
       )}
     >
-      {MYPAGE_BOTTOM_NAV.map(el => (
-        <button key={el} type="button" className="mx-4">
-          <p className="hover:underline">{el}</p>
-        </button>
-      ))}
+      <button type="button" className="mx-4" onClick={handleLogout}>
+        <p className="hover:underline">로그아웃</p>
+      </button>
+      <button type="button" className="mx-4">
+        <p className="hover:underline">회원 탈퇴</p>
+      </button>
     </div>
   );
 }

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,16 @@
+import { usePageNav } from '@/hooks/usePageNav';
+import { useUserStore } from '@/stores/userStore';
+
+export const useLogout = () => {
+  const { logout } = useUserStore();
+  const { navigateToLanding } = usePageNav();
+
+  const handleLogout = () => {
+    if (confirm('로그아웃 하시겠습니까?')) {
+      logout();
+      navigateToLanding();
+    }
+  };
+
+  return { handleLogout };
+};

--- a/src/hooks/usePageNav.ts
+++ b/src/hooks/usePageNav.ts
@@ -15,5 +15,14 @@ export const usePageNav = () => {
     navigate('/search');
   };
 
-  return { navigateToLogin, navigateToSignup, navigateToSearch };
+  const navigateToMypage = () => {
+    navigate('/mypage/myprofile');
+  };
+
+  return {
+    navigateToLogin,
+    navigateToSignup,
+    navigateToSearch,
+    navigateToMypage,
+  };
 };

--- a/src/hooks/usePageNav.ts
+++ b/src/hooks/usePageNav.ts
@@ -3,6 +3,10 @@ import { useNavigate } from 'react-router-dom';
 export const usePageNav = () => {
   const navigate = useNavigate();
 
+  const navigateToLanding = () => {
+    navigate('/');
+  };
+
   const navigateToLogin = () => {
     navigate('/auth/login');
   };
@@ -20,6 +24,7 @@ export const usePageNav = () => {
   };
 
   return {
+    navigateToLanding,
     navigateToLogin,
     navigateToSignup,
     navigateToSearch,

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,6 +16,7 @@ import {
   showSuccessToast,
   toastFormErrors,
 } from '@/utils/toastUtils';
+import { useUserStore } from '@/stores/userStore';
 
 const USER_TYPE = [
   { id: 'NORMAL', label: '일반 회원 (팬)' },
@@ -25,6 +26,7 @@ const USER_TYPE = [
 
 export default function Login() {
   const { navigateToSearch } = usePageNav();
+  const { login } = useUserStore();
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -47,6 +49,30 @@ export default function Login() {
         password: data.password,
         userType: data.userType,
       });
+
+      // 실제 API 응답 구조에 맞춰 데이터 파싱
+      const {
+        user_id,
+        access_token,
+        refresh_token,
+        profile_image_url,
+        role,
+        email: userEmail,
+        username: userNickname,
+      } = response.data.data;
+
+      // userStore의 login 액션 호출
+      login(
+        {
+          user_id: user_id,
+          email: userEmail,
+          nickname: userNickname,
+          profile_image_url: profile_image_url,
+          role: role,
+        },
+        access_token,
+        refresh_token,
+      );
 
       showSuccessToast(response.data.message || '로그인 성공!');
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,12 +11,12 @@ import Select from '@/components/common/Select';
 import { GoogleIcon, KakaoIcon } from '@/components/SocialIcons';
 import { usePageNav } from '@/hooks/usePageNav';
 import { type LoginFormValues, LoginSchema } from '@/schemas/loginSchema';
+import { useUserStore } from '@/stores/userStore';
 import {
   showErrorToast,
   showSuccessToast,
   toastFormErrors,
 } from '@/utils/toastUtils';
-import { useUserStore } from '@/stores/userStore';
 
 const USER_TYPE = [
   { id: 'NORMAL', label: '일반 회원 (팬)' },
@@ -50,28 +50,26 @@ export default function Login() {
         userType: data.userType,
       });
 
-      // 실제 API 응답 구조에 맞춰 데이터 파싱
       const {
-        user_id,
-        access_token,
-        refresh_token,
-        profile_image_url,
+        user_id: userId,
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        profile_image_url: profileImageUrl,
         role,
         email: userEmail,
         username: userNickname,
       } = response.data.data;
 
-      // userStore의 login 액션 호출
       login(
         {
-          user_id: user_id,
+          user_id: userId,
           email: userEmail,
           nickname: userNickname,
-          profile_image_url: profile_image_url,
-          role: role,
+          profile_image_url: profileImageUrl,
+          role,
         },
-        access_token,
-        refresh_token,
+        accessToken,
+        refreshToken,
       );
 
       showSuccessToast(response.data.message || '로그인 성공!');

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -1,0 +1,55 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface UserState {
+  user: {
+    user_id: string;
+    email: string;
+    nickname: string;
+    profile_image_url: string;
+    role: string;
+  } | null;
+  isLoggedIn: boolean;
+  accessToken: string | null;
+  refreshToken: string | null;
+  login: (
+    user: {
+      user_id: string;
+      email: string;
+      nickname: string;
+      profile_image_url: string;
+      role: string;
+    },
+    accessToken: string,
+    refreshToken: string,
+  ) => void;
+  logout: () => void;
+}
+
+export const useUserStore = create<UserState>()(
+  persist(
+    set => ({
+      user: null,
+      isLoggedIn: false,
+      accessToken: null,
+      refreshToken: null,
+      login: (user, accessToken, refreshToken) =>
+        set({
+          user,
+          isLoggedIn: true,
+          accessToken,
+          refreshToken,
+        }),
+      logout: () =>
+        set({
+          user: null,
+          isLoggedIn: false,
+          accessToken: null,
+          refreshToken: null,
+        }),
+    }),
+    {
+      name: 'user-storage',
+    },
+  ),
+);


### PR DESCRIPTION
## 🚀 PR 요약

사용자 정보 전역 상태를 생성하고 사용자 정보가 필요한 부분에 전역 상태를 적용하면서 리팩토링 작업을 했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가
- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

### 로그인 시 로컬 스토리지에 사용자 정보 저장 (zustand의 persist 미들웨어 기능)
<img width="1321" height="436" alt="스크린샷 2025-08-22 105247" src="https://github.com/user-attachments/assets/eee63046-1983-4e68-9ff4-7ef1c498a1f4" />

### 로그인 후 헤더 조건부 렌더링
<img width="1227" height="526" alt="image" src="https://github.com/user-attachments/assets/5ba67b2d-178f-4b15-916b-4786dbb4be82" />

### 로그아웃 시
confirm으로 로그아웃 확인을 받도록 하였는데 추후에 모달을 사용하도록 수정하겠습니다.
<img width="505" height="275" alt="image" src="https://github.com/user-attachments/assets/50161459-f8a4-4324-b625-6ca0be3b3f41" />


## 🔗 연관된 이슈

> closes #123, relates to #456 등의 형식으로 입력
