### PR TITLE
Fix: Vercel SPA fallback 설정 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## 🚀 PR 요약

Vercel 배포 환경에서 **/chat** 등 클라이언트 라우트 접근 시 발생하는 404 오류를 해결하기 위해 SPA fallback 설정(vercel.json)을 추가했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

- API base-url이 사이트 도메인과 같다면 예외 처리를 해주어야 하지만, 저희 프로젝트 서버(https://api.moyeoradingding.site)는 별도 도메인에서 동작하므로 /api 예외 처리는 따로 하지 않았습니다.
- 정적 리소스(.js, .css)는 Vercel이 자동 처리하므로 리소스 로딩에 영향은 없습니다.

## 🔗 연관된 이슈

> closes #143 
