### PR TITLE
 Feat: 아이돌/매니저 메인 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import IdolSearchPage from '@/pages/idolSearch/IdolSearchPage';
 import LandingPage from '@/pages/landing/LandingPage';
 import Login from '@/pages/Login';
 import FanMainPage from '@/pages/main/fan/FanMainPage';
+import IdolMainPage from '@/pages/main/idol/IdolMainPage';
 import MyProfile from '@/pages/MyProfile';
 import MySchedule from '@/pages/MySchedule';
 import Register from '@/pages/Register';
@@ -34,6 +35,10 @@ function App() {
 
       <Route path="/idols" element={<Layout />}>
         <Route path=":idolId" element={<FanMainPage />} />
+      </Route>
+
+      <Route path="/main" element={<Layout />}>
+        <Route path="idol" element={<IdolMainPage />} />
       </Route>
 
       <Route path="/mypage" element={<MyPageLayout />}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import LandingPage from '@/pages/landing/LandingPage';
 import Login from '@/pages/Login';
 import FanMainPage from '@/pages/main/fan/FanMainPage';
 import IdolMainPage from '@/pages/main/idol/IdolMainPage';
+import ManagerMainPage from '@/pages/main/manager/ManagerMainPage';
 import MyProfile from '@/pages/MyProfile';
 import MySchedule from '@/pages/MySchedule';
 import Register from '@/pages/Register';
@@ -39,6 +40,7 @@ function App() {
 
       <Route path="/main" element={<Layout />}>
         <Route path="idol" element={<IdolMainPage />} />
+        <Route path="manager" element={<ManagerMainPage />} />
       </Route>
 
       <Route path="/mypage" element={<MyPageLayout />}>

--- a/src/components/common/dateSchedule/DateScheduleItem.tsx
+++ b/src/components/common/dateSchedule/DateScheduleItem.tsx
@@ -22,7 +22,6 @@ import { IconButton } from './IconButton';
 const iconSize = 'h-5 w-5 sm:h-6 sm:w-6';
 const iconColor = 'text-fuchsia-600';
 
-/** 아이콘 타입을 실제 아이콘으로 렌더링 (예: 'star' → <StarIcon />) */
 function renderIcon(icon: ActionIcon): React.ReactNode {
   switch (icon) {
     case 'star':
@@ -73,13 +72,13 @@ export default function DateScheduleItem({
 
   return (
     <li className="rounded-2xl transition hover:bg-gray-50">
-      <div className="flex min-h-[64px] items-center overflow-hidden rounded-lg bg-fuchsia-100 py-3 pr-8 pl-12 sm:min-h-[72px] sm:py-4 sm:pr-10 sm:pl-16 md:min-h-[80px] md:pr-12 md:pl-20">
+      <div className="flex min-h-[64px] items-center overflow-hidden rounded-lg bg-fuchsia-100 px-4 py-3 sm:min-h-[72px] sm:px-6 sm:py-4 md:min-h-[80px] md:px-8">
         <button
           type="button"
           onClick={handleToggleOpen}
           aria-expanded={isOpen}
           aria-controls={`schedule-detail-${item.id}`}
-          className="mr-2 shrink-0 basis-[100px] text-left sm:mr-3 sm:basis-[112px] md:mr-4 md:basis-[120px]"
+          className="w-[72px] pr-5 text-right sm:w-[84px] sm:pr-6 md:w-[96px] md:pr-8"
         >
           <span className="text-base whitespace-nowrap text-gray-700 tabular-nums select-none sm:text-lg">
             {time}
@@ -92,14 +91,17 @@ export default function DateScheduleItem({
           aria-expanded={isOpen}
           aria-controls={`schedule-detail-${item.id}`}
           title={item.title}
-          className="min-w-0 flex-1 truncate pl-1 text-left sm:pl-2 md:pl-3"
+          className="min-w-0 flex-1 truncate pr-2 pl-5 text-left sm:pr-3 sm:pl-6 md:pr-4 md:pl-8"
         >
-          <span className="block text-base text-gray-700 sm:text-lg">
+          <span
+            className="block truncate text-base text-gray-700 sm:text-lg"
+            title={item.title}
+          >
             {item.title}
           </span>
         </button>
 
-        <div className="shrink-0 basis-[88px] sm:basis-[100px] md:basis-[108px]">
+        <div className="w-[72px] pl-2 sm:w-[84px] md:w-[96px]">
           <div className="flex justify-end gap-1">
             {actionsInfo.map(action => (
               <IconButton
@@ -117,28 +119,30 @@ export default function DateScheduleItem({
       {isOpen && (
         <div
           id={`schedule-detail-${item.id}`}
-          className="rounded-xl bg-fuchsia-50 p-3 pl-[72px] text-sm text-gray-800 sm:p-4 sm:pl-[84px] sm:text-base md:pl-[96px]"
+          className="rounded-xl bg-fuchsia-50 p-3 text-sm text-gray-800 sm:p-4 sm:text-base"
         >
-          {item.place || item.location ? (
-            <p>장소: {item.place || item.location}</p>
-          ) : (
-            <p className="font-medium">{item.title}</p>
-          )}
-          <p>날짜: {formatDateSlash(displayDate)}</p>
+          <div className="ml-[92px] sm:ml-[108px] md:ml-[128px]">
+            {item.place || item.location ? (
+              <p>장소: {item.place || item.location}</p>
+            ) : (
+              <p className="font-medium">{item.title}</p>
+            )}
+            <p>날짜: {formatDateSlash(displayDate)}</p>
 
-          {isGroupSchedule(item) && (
-            <p>
-              아티스트: {item.group.name}
-              {item.members &&
-                item.members.length > 0 &&
-                ` (${item.members.map(m => m.name).join(', ')})`}
-            </p>
-          )}
-          {isIdolSchedule(item) && <p>아티스트: {item.idol.name}</p>}
+            {isGroupSchedule(item) && (
+              <p>
+                아티스트: {item.group.name}
+                {item.members &&
+                  item.members.length > 0 &&
+                  ` (${item.members.map(m => m.name).join(', ')})`}
+              </p>
+            )}
+            {isIdolSchedule(item) && <p>아티스트: {item.idol.name}</p>}
 
-          {item.description && (
-            <p className="mt-2 whitespace-pre-wrap">{item.description}</p>
-          )}
+            {item.description && (
+              <p className="mt-2 whitespace-pre-wrap">{item.description}</p>
+            )}
+          </div>
         </div>
       )}
     </li>

--- a/src/components/common/dateSchedule/DateScheduleItem.tsx
+++ b/src/components/common/dateSchedule/DateScheduleItem.tsx
@@ -119,7 +119,11 @@ export default function DateScheduleItem({
           id={`schedule-detail-${item.id}`}
           className="rounded-xl bg-fuchsia-50 p-3 pl-[72px] text-sm text-gray-800 sm:p-4 sm:pl-[84px] sm:text-base md:pl-[96px]"
         >
-          <p className="font-medium">{item.title}</p>
+          {item.place || item.location ? (
+            <p>장소: {item.place || item.location}</p>
+          ) : (
+            <p className="font-medium">{item.title}</p>
+          )}
           <p>날짜: {formatDateSlash(displayDate)}</p>
 
           {isGroupSchedule(item) && (

--- a/src/components/common/modal/ScheduleFormModal.tsx
+++ b/src/components/common/modal/ScheduleFormModal.tsx
@@ -157,9 +157,6 @@ export default function ScheduleFormModal({
 
       <div className="mt-4 flex gap-3">
         <Button onClick={handleSave}>저장하기</Button>
-        <Button variant="secondary" onClick={onClose}>
-          취소
-        </Button>
       </div>
     </Modal>
   );

--- a/src/components/common/modal/ScheduleFormModal.tsx
+++ b/src/components/common/modal/ScheduleFormModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '../Button';
 import Input from '../input';
@@ -34,38 +34,83 @@ export default function ScheduleFormModal({
   initialValues,
   onSubmit,
 }: ScheduleFormModalProps) {
-  const EMPTY = {
-    title: '',
-    date: '',
-    time: '',
-    place: '',
-    description: '',
-    isPublic: false,
-  };
+  const EMPTY = useMemo(
+    () => ({
+      title: '',
+      date: '',
+      time: '',
+      place: '',
+      description: '',
+      isPublic: false,
+    }),
+    [],
+  );
 
   const [values, setValues] = useState(EMPTY);
 
   useEffect(() => {
     if (!isOpen) return;
     setValues({ ...EMPTY, ...initialValues });
-  }, [isOpen, initialValues]);
+  }, [isOpen, initialValues, EMPTY]);
 
-  async function handleSave() {
+  const handleSave = useCallback(async () => {
     if (!values.title.trim()) {
-      alert('제목을 입력해 주세요.');
+      // eslint-disable-next-line no-console
+      console.warn('제목을 입력해 주세요.');
       return;
     }
     if (!values.date || !values.time) {
-      alert('날짜와 시간을 입력해 주세요.');
+      // eslint-disable-next-line no-console
+      console.warn('날짜와 시간을 입력해 주세요.');
       return;
     }
     try {
       await onSubmit?.(values);
       onClose();
     } catch (err) {
-      alert('저장 중 오류가 발생했습니다.');
+      // eslint-disable-next-line no-console
+      console.error('저장 중 오류가 발생했습니다.', err);
     }
-  }
+  }, [values, onSubmit, onClose]);
+
+  const handleTitleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setValues(s => ({ ...s, title: e.target.value }));
+    },
+    [],
+  );
+
+  const handleDateChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setValues(s => ({ ...s, date: e.target.value }));
+    },
+    [],
+  );
+
+  const handleTimeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setValues(s => ({ ...s, time: e.target.value }));
+    },
+    [],
+  );
+
+  const handlePlaceChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setValues(s => ({ ...s, place: e.target.value }));
+    },
+    [],
+  );
+
+  const handleDescriptionChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setValues(s => ({ ...s, description: e.target.value }));
+    },
+    [],
+  );
+
+  const handleToggleChange = useCallback((next: boolean) => {
+    setValues(s => ({ ...s, isPublic: next }));
+  }, []);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={title}>
@@ -74,50 +119,38 @@ export default function ScheduleFormModal({
           type="text"
           label="제목"
           value={values.title}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setValues(s => ({ ...s, title: e.target.value }))
-          }
+          onChange={handleTitleChange}
         />
         <Input
           type="date"
           label="날짜"
           value={values.date}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setValues(s => ({ ...s, date: e.target.value }))
-          }
+          onChange={handleDateChange}
         />
         <Input
           type="time"
           label="시간"
           value={values.time}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setValues(s => ({ ...s, time: e.target.value }))
-          }
+          onChange={handleTimeChange}
         />
         <Input
           type="text"
           label="장소"
           value={values.place}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setValues(s => ({ ...s, place: e.target.value }))
-          }
+          onChange={handlePlaceChange}
         />
         <Input
           type="textarea"
           label="설명"
           value={values.description}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-            setValues(s => ({ ...s, description: e.target.value }))
-          }
+          onChange={handleDescriptionChange}
         />
 
         <div className="mt-1 mr-[2px] flex items-center justify-between">
           <p>공개 여부</p>
           <ToggleButton
             checked={values.isPublic}
-            onChange={(next: boolean) =>
-              setValues(s => ({ ...s, isPublic: next }))
-            }
+            onChange={handleToggleChange}
           />
         </div>
       </div>

--- a/src/components/common/modal/ScheduleFormModal.tsx
+++ b/src/components/common/modal/ScheduleFormModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Button } from '../Button';
 import Input from '../input';
@@ -9,31 +9,125 @@ interface ScheduleFormModalProps {
   isOpen: boolean;
   onClose: () => void;
   title: string;
+  initialValues?: {
+    title?: string;
+    date?: string; // YYYY-MM-DD
+    time?: string; // HH:mm
+    place?: string;
+    description?: string;
+    isPublic?: boolean;
+  };
+  onSubmit?: (form: {
+    title: string;
+    date: string;
+    time: string;
+    place: string;
+    description: string;
+    isPublic: boolean;
+  }) => void | Promise<void>;
 }
 
 export default function ScheduleFormModal({
   isOpen,
   onClose,
   title,
+  initialValues,
+  onSubmit,
 }: ScheduleFormModalProps) {
-  const [isOn, setIsOn] = useState(false);
+  const EMPTY = {
+    title: '',
+    date: '',
+    time: '',
+    place: '',
+    description: '',
+    isPublic: false,
+  };
+
+  const [values, setValues] = useState(EMPTY);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setValues({ ...EMPTY, ...initialValues });
+  }, [isOpen, initialValues]);
+
+  async function handleSave() {
+    if (!values.title.trim()) {
+      alert('제목을 입력해 주세요.');
+      return;
+    }
+    if (!values.date || !values.time) {
+      alert('날짜와 시간을 입력해 주세요.');
+      return;
+    }
+    try {
+      await onSubmit?.(values);
+      onClose();
+    } catch (err) {
+      alert('저장 중 오류가 발생했습니다.');
+    }
+  }
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={title}>
-      <div className="flex w-full flex-col gap-2">
-        <Input type="date" label="날짜" />
-        <Input type="time" label="시간" />
-        <Input type="text" label="장소" />
-        <Input type="textarea" label="설명" />
-        <div className="mr-[2px] flex items-center justify-between">
+      <div className="flex w-full flex-col gap-3">
+        <Input
+          type="text"
+          label="제목"
+          value={values.title}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setValues(s => ({ ...s, title: e.target.value }))
+          }
+        />
+        <Input
+          type="date"
+          label="날짜"
+          value={values.date}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setValues(s => ({ ...s, date: e.target.value }))
+          }
+        />
+        <Input
+          type="time"
+          label="시간"
+          value={values.time}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setValues(s => ({ ...s, time: e.target.value }))
+          }
+        />
+        <Input
+          type="text"
+          label="장소"
+          value={values.place}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setValues(s => ({ ...s, place: e.target.value }))
+          }
+        />
+        <Input
+          type="textarea"
+          label="설명"
+          value={values.description}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setValues(s => ({ ...s, description: e.target.value }))
+          }
+        />
+
+        <div className="mt-1 mr-[2px] flex items-center justify-between">
           <p>공개 여부</p>
           <ToggleButton
-            checked={isOn}
-            onChange={nextState => setIsOn(nextState)}
+            checked={values.isPublic}
+            onChange={(next: boolean) =>
+              setValues(s => ({ ...s, isPublic: next }))
+            }
           />
         </div>
       </div>
-      <Button onClick={onClose}>저장하기</Button>
+
+      <div className="mt-4 flex gap-3">
+        <Button onClick={handleSave}>저장하기</Button>
+        <Button variant="secondary" onClick={onClose}>
+          취소
+        </Button>
+      </div>
     </Modal>
   );
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,7 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import { zodResolver } from '@hookform/resolvers/zod';
+import axios from 'axios';
+import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
@@ -7,9 +9,14 @@ import { Button } from '@/components/common/Button';
 import Input from '@/components/common/input';
 import Select from '@/components/common/Select';
 import { GoogleIcon, KakaoIcon } from '@/components/SocialIcons';
-import { useLogin } from '@/hooks/useLogin';
+import { usePageNav } from '@/hooks/usePageNav';
 import { type LoginFormValues, LoginSchema } from '@/schemas/loginSchema';
-import { toastFormErrors } from '@/utils/toastUtils';
+import { useUserStore } from '@/stores/userStore';
+import {
+  showErrorToast,
+  showSuccessToast,
+  toastFormErrors,
+} from '@/utils/toastUtils';
 
 const USER_TYPE = [
   { id: 'NORMAL', label: '일반 회원 (팬)' },
@@ -18,7 +25,10 @@ const USER_TYPE = [
 ];
 
 export default function Login() {
-  const { submit, isLoading } = useLogin();
+  const { navigateToSearch } = usePageNav();
+  const { login } = useUserStore();
+
+  const [isLoading, setIsLoading] = useState(false);
 
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(LoginSchema),
@@ -30,6 +40,68 @@ export default function Login() {
 
   const { register } = form;
 
+  const onSubmit = async (data: LoginFormValues) => {
+    setIsLoading(true);
+    try {
+      // 1. 로그인 요청으로 토큰 받아오기
+      const loginResponse = await axios.post('/users/login', {
+        email: data.email,
+        password: data.password,
+      });
+
+      const { access_token: accessToken, refresh_token: refreshToken } =
+        loginResponse.data;
+
+      if (!accessToken) {
+        showErrorToast('로그인에 실패했습니다. 토큰이 없습니다.');
+        setIsLoading(false);
+        return;
+      }
+
+      // 2. 받아온 토큰으로 마이페이지 정보 요청
+      const profileResponse = await axios.get('/users/mypage', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        id: userId,
+        email: userEmail,
+        nickname,
+        profile_image_url: profileImageUrl,
+        role,
+      } = profileResponse.data;
+
+      // 3. 스토어에 사용자 정보와 토큰 저장
+      login(
+        {
+          user_id: userId,
+          email: userEmail,
+          nickname,
+          profile_image_url: profileImageUrl,
+          role,
+        },
+        accessToken,
+        refreshToken,
+      );
+
+      showSuccessToast('로그인 성공!');
+      navigateToSearch();
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        showErrorToast(
+          error.response.data.message ||
+            '로그인 또는 프로필 조회에 실패했습니다.',
+        );
+      } else {
+        showErrorToast('로그인 중 네트워크 오류가 발생했습니다.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-2">
       <div>
@@ -38,7 +110,7 @@ export default function Login() {
       </div>
 
       <form
-        onSubmit={form.handleSubmit(submit, toastFormErrors)}
+        onSubmit={form.handleSubmit(onSubmit, toastFormErrors)}
         className="flex flex-col gap-2"
       >
         <Controller

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,5 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import { zodResolver } from '@hookform/resolvers/zod';
-import axios from 'axios';
-import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
@@ -9,14 +7,9 @@ import { Button } from '@/components/common/Button';
 import Input from '@/components/common/input';
 import Select from '@/components/common/Select';
 import { GoogleIcon, KakaoIcon } from '@/components/SocialIcons';
-import { usePageNav } from '@/hooks/usePageNav';
+import { useLogin } from '@/hooks/useLogin';
 import { type LoginFormValues, LoginSchema } from '@/schemas/loginSchema';
-import { useUserStore } from '@/stores/userStore';
-import {
-  showErrorToast,
-  showSuccessToast,
-  toastFormErrors,
-} from '@/utils/toastUtils';
+import { toastFormErrors } from '@/utils/toastUtils';
 
 const USER_TYPE = [
   { id: 'NORMAL', label: '일반 회원 (팬)' },
@@ -25,10 +18,7 @@ const USER_TYPE = [
 ];
 
 export default function Login() {
-  const { navigateToSearch } = usePageNav();
-  const { login } = useUserStore();
-
-  const [isLoading, setIsLoading] = useState(false);
+  const { submit, isLoading } = useLogin();
 
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(LoginSchema),
@@ -40,68 +30,6 @@ export default function Login() {
 
   const { register } = form;
 
-  const onSubmit = async (data: LoginFormValues) => {
-    setIsLoading(true);
-    try {
-      // 1. 로그인 요청으로 토큰 받아오기
-      const loginResponse = await axios.post('/users/login', {
-        email: data.email,
-        password: data.password,
-      });
-
-      const { access_token: accessToken, refresh_token: refreshToken } =
-        loginResponse.data;
-
-      if (!accessToken) {
-        showErrorToast('로그인에 실패했습니다. 토큰이 없습니다.');
-        setIsLoading(false);
-        return;
-      }
-
-      // 2. 받아온 토큰으로 마이페이지 정보 요청
-      const profileResponse = await axios.get('/users/mypage', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
-
-      const {
-        id: userId,
-        email: userEmail,
-        nickname,
-        profile_image_url: profileImageUrl,
-        role,
-      } = profileResponse.data;
-
-      // 3. 스토어에 사용자 정보와 토큰 저장
-      login(
-        {
-          user_id: userId,
-          email: userEmail,
-          nickname,
-          profile_image_url: profileImageUrl,
-          role,
-        },
-        accessToken,
-        refreshToken,
-      );
-
-      showSuccessToast('로그인 성공!');
-      navigateToSearch();
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        showErrorToast(
-          error.response.data.message ||
-            '로그인 또는 프로필 조회에 실패했습니다.',
-        );
-      } else {
-        showErrorToast('로그인 중 네트워크 오류가 발생했습니다.');
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   return (
     <div className="flex flex-col gap-2">
       <div>
@@ -110,7 +38,7 @@ export default function Login() {
       </div>
 
       <form
-        onSubmit={form.handleSubmit(onSubmit, toastFormErrors)}
+        onSubmit={form.handleSubmit(submit, toastFormErrors)}
         className="flex flex-col gap-2"
       >
         <Controller

--- a/src/pages/main/fan/FanMainPage.tsx
+++ b/src/pages/main/fan/FanMainPage.tsx
@@ -63,6 +63,7 @@ export default function FanMainPage() {
         userRole="fan"
         title={`${currentIdol.name}의 일정을\n확인해보세요`}
         leftIcon={leftIcon}
+        leftIconClassName="self-start mt-1"
         rightAction={rightAction}
       />
       <CalendarScheduleLayout

--- a/src/pages/main/idol/IdolMainPage.tsx
+++ b/src/pages/main/idol/IdolMainPage.tsx
@@ -1,9 +1,9 @@
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
 import { Button } from '@/components/common/Button';
 import Calendar from '@/components/common/calendar/Calendar';
 import DateScheduleList from '@/components/common/dateSchedule/DateScheduleList';
 import { CalendarScheduleLayout, Greeting } from '../shared';
 import { useIdolMainData } from './hooks/useIdolMainData';
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
 
 export default function IdolMainPage() {
   const { selectedDate, setSelectedDate, filteredSchedules } =
@@ -19,9 +19,9 @@ export default function IdolMainPage() {
       variant="outline"
       shape="pill"
       size="lg"
-      className="group mt-6 flex items-center gap-2 border border-fuchsia-400 px-4 py-2 font-bold whitespace-nowrap text-fuchsia-500 transition-colors hover:bg-fuchsia-400 hover:text-white lg:ml-6"
+      className="group mt-6 flex items-center gap-2 border-fuchsia-400 px-6 font-bold whitespace-nowrap text-fuchsia-600 hover:bg-fuchsia-400 hover:text-white lg:ml-6"
     >
-      <ChatBubbleLeftRightIcon className="h-6 w-6 text-fuchsia-400 transition-colors group-hover:text-white" />
+      <ChatBubbleLeftRightIcon className="h-5 w-5 text-fuchsia-400 transition-colors group-hover:text-white" />
       매니저와 채팅
     </Button>
   );
@@ -30,11 +30,11 @@ export default function IdolMainPage() {
     <div className="mx-auto mb-16 max-w-screen-xl px-3 pt-12 md:px-8 lg:mb-24 lg:px-2 lg:pt-6">
       <Greeting
         userRole="idol"
-        title={`안녕하세요, 카리나님!`}
+        title="안녕하세요, 카리나님!"
         subtitle="오늘의 스케줄을 확인해보세요."
-        subtitleClassName="mt-4"
         rightAction={rightAction}
       />
+
       <CalendarScheduleLayout
         dailyMinWidth={420}
         calendar={

--- a/src/pages/main/idol/IdolMainPage.tsx
+++ b/src/pages/main/idol/IdolMainPage.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@/components/common/Button';
+import Calendar from '@/components/common/calendar/Calendar';
+import DateScheduleList from '@/components/common/dateSchedule/DateScheduleList';
+import { CalendarScheduleLayout, Greeting } from '../shared';
+import { useIdolMainData } from './hooks/useIdolMainData';
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
+
+export default function IdolMainPage() {
+  const { selectedDate, setSelectedDate, filteredSchedules } =
+    useIdolMainData();
+
+  function handleChatClick() {
+    alert('매니저와 채팅하기로 이동');
+  }
+
+  const rightAction = (
+    <Button
+      onClick={handleChatClick}
+      variant="outline"
+      shape="pill"
+      size="lg"
+      className="group mt-6 flex items-center gap-2 border border-fuchsia-400 px-4 py-2 font-bold whitespace-nowrap text-fuchsia-500 transition-colors hover:bg-fuchsia-400 hover:text-white lg:ml-6"
+    >
+      <ChatBubbleLeftRightIcon className="h-6 w-6 text-fuchsia-400 transition-colors group-hover:text-white" />
+      매니저와 채팅
+    </Button>
+  );
+
+  return (
+    <div className="mx-auto mb-16 max-w-screen-xl px-3 pt-12 md:px-8 lg:mb-24 lg:px-2 lg:pt-6">
+      <Greeting
+        userRole="idol"
+        title={`안녕하세요, 카리나님!`}
+        subtitle="오늘의 스케줄을 확인해보세요."
+        subtitleClassName="mt-4"
+        rightAction={rightAction}
+      />
+      <CalendarScheduleLayout
+        dailyMinWidth={420}
+        calendar={
+          <Calendar
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            schedules={filteredSchedules}
+          />
+        }
+        daily={
+          <DateScheduleList
+            userRole="idol"
+            selectedDate={selectedDate.format('YYYY-MM-DD')}
+            schedules={filteredSchedules}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/src/pages/main/idol/IdolMainPage.tsx
+++ b/src/pages/main/idol/IdolMainPage.tsx
@@ -24,7 +24,7 @@ export default function IdolMainPage() {
       size="lg"
       className="group mt-6 flex items-center gap-2 border-fuchsia-400 px-6 font-bold whitespace-nowrap text-fuchsia-600 hover:bg-fuchsia-400 hover:text-white lg:ml-6"
     >
-      <ChatBubbleLeftRightIcon className="h-5 w-5 text-fuchsia-400 transition-colors group-hover:text-white" />
+      <ChatBubbleLeftRightIcon className="h-5 w-5 text-fuchsia-500 transition-colors group-hover:text-white" />
       매니저와 채팅
     </Button>
   );

--- a/src/pages/main/idol/IdolMainPage.tsx
+++ b/src/pages/main/idol/IdolMainPage.tsx
@@ -1,7 +1,10 @@
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
+import { useCallback } from 'react';
+
 import { Button } from '@/components/common/Button';
 import Calendar from '@/components/common/calendar/Calendar';
 import DateScheduleList from '@/components/common/dateSchedule/DateScheduleList';
+
 import { CalendarScheduleLayout, Greeting } from '../shared';
 import { useIdolMainData } from './hooks/useIdolMainData';
 
@@ -9,9 +12,9 @@ export default function IdolMainPage() {
   const { selectedDate, setSelectedDate, filteredSchedules } =
     useIdolMainData();
 
-  function handleChatClick() {
-    alert('매니저와 채팅하기로 이동');
-  }
+  const handleChatClick = useCallback(() => {
+    // TODO: 실제 라우팅 연결 (예: navigate('/chat'))
+  }, []);
 
   const rightAction = (
     <Button

--- a/src/pages/main/idol/hooks/useIdolMainData.ts
+++ b/src/pages/main/idol/hooks/useIdolMainData.ts
@@ -1,0 +1,28 @@
+import { useEffect, useMemo, useState } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+
+export function useIdolMainData() {
+  const [selectedDate, setSelectedDate] = useState<Dayjs>(() => dayjs());
+  const [allSchedules, setAllSchedules] = useState<any[]>([]);
+
+  useEffect(() => {
+    const iso = selectedDate.format('YYYY-MM-DD');
+    setAllSchedules([
+      {
+        id: 'a1',
+        title: '라디오 출연',
+        startTime: `${iso}T09:30:00`,
+        idol: { name: '아이돌 A' },
+      },
+      {
+        id: 'a2',
+        title: '연습',
+        startTime: `${iso}T14:00:00`,
+        idol: { name: '아이돌 A' },
+      },
+    ]);
+  }, [selectedDate]);
+
+  const filteredSchedules = useMemo(() => allSchedules, [allSchedules]);
+  return { selectedDate, setSelectedDate, filteredSchedules };
+}

--- a/src/pages/main/idol/hooks/useIdolMainData.ts
+++ b/src/pages/main/idol/hooks/useIdolMainData.ts
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import type { Schedule, IdolSchedule } from '@/types/schedule';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { IdolSchedule, Schedule } from '@/types/schedule';
 
 export function useIdolMainData() {
   const [selectedDate, setSelectedDate] = useState<Dayjs>(() => dayjs());

--- a/src/pages/main/idol/hooks/useIdolMainData.ts
+++ b/src/pages/main/idol/hooks/useIdolMainData.ts
@@ -1,28 +1,39 @@
 import { useEffect, useMemo, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
+import type { Schedule, IdolSchedule } from '@/types/schedule';
 
 export function useIdolMainData() {
   const [selectedDate, setSelectedDate] = useState<Dayjs>(() => dayjs());
-  const [allSchedules, setAllSchedules] = useState<any[]>([]);
+  const [allSchedules, setAllSchedules] = useState<Schedule[]>([]);
 
   useEffect(() => {
     const iso = selectedDate.format('YYYY-MM-DD');
-    setAllSchedules([
+
+    // TODO: API 연동: GET /idol/me/schedules?date=iso
+    const mock: IdolSchedule[] = [
       {
-        id: 'a1',
+        id: 1,
         title: '라디오 출연',
         startTime: `${iso}T09:30:00`,
-        idol: { name: '아이돌 A' },
+        endTime: `${iso}T10:30:00`,
+        isPublic: true,
+        idol: { id: 101, name: '아이돌 A' },
+        description: 'SBS 파워FM 생방',
       },
       {
-        id: 'a2',
-        title: '연습',
+        id: 2,
+        title: '안무 연습',
         startTime: `${iso}T14:00:00`,
-        idol: { name: '아이돌 A' },
+        endTime: `${iso}T16:00:00`,
+        isPublic: true,
+        idol: { id: 101, name: '아이돌 A' },
       },
-    ]);
+    ];
+
+    setAllSchedules(mock as Schedule[]);
   }, [selectedDate]);
 
   const filteredSchedules = useMemo(() => allSchedules, [allSchedules]);
+
   return { selectedDate, setSelectedDate, filteredSchedules };
 }

--- a/src/pages/main/manager/ManagerMainPage.tsx
+++ b/src/pages/main/manager/ManagerMainPage.tsx
@@ -25,19 +25,20 @@ export default function ManagerMainPage() {
         onClick={handleAddClick}
         shape="pill"
         size="lg"
-        className="flex items-center gap-2 bg-fuchsia-100 px-5 font-semibold text-fuchsia-700 hover:bg-fuchsia-200"
+        className="inline-flex min-w-[185px] items-center justify-center gap-2 bg-fuchsia-100 px-6 font-semibold whitespace-nowrap hover:bg-fuchsia-500 hover:text-white"
       >
-        <PlusIcon className="h-5 w-5" />
+        <PlusIcon className="h-6 w-6" />
         일정 등록
       </Button>
+
       <Button
         onClick={() => alert('아이돌과 채팅으로 이동')}
         variant="outline"
         shape="pill"
         size="lg"
-        className="group flex items-center gap-2 border-fuchsia-400 px-5 font-semibold text-fuchsia-600 hover:bg-fuchsia-400 hover:text-white"
+        className="group inline-flex min-w-[185px] items-center justify-center gap-2 border-fuchsia-400 px-6 font-semibold whitespace-nowrap hover:bg-fuchsia-500 hover:text-white"
       >
-        <ChatBubbleLeftRightIcon className="h-5 w-5 text-fuchsia-400 transition-colors group-hover:text-white" />
+        <ChatBubbleLeftRightIcon className="h-6 w-6 text-fuchsia-400 transition-colors group-hover:text-white" />
         아이돌과 채팅
       </Button>
     </div>
@@ -48,21 +49,22 @@ export default function ManagerMainPage() {
       <Greeting
         userRole="manager"
         title="안녕하세요, 매니저 A님!"
-        subtitle="오늘 담당 아티스트의 일정을 관리하세요."
+        subtitle={
+          <span className="inline-flex items-center gap-2">
+            현재 담당 아이돌은
+            <Select
+              list={idols}
+              value={currentIdolId}
+              onChange={v => setCurrentIdolId(Number(v))}
+              size="small"
+              className="inline-block min-w-[100px] py-2 pr-7 pl-2 text-base leading-tight before:right-2"
+            />
+            입니다.
+          </span>
+        }
         rightAction={rightAction}
+        subtitleClassName="mt-3 lg:mt-4"
       />
-
-      <div className="mb-4 lg:mb-2">
-        <span className="mr-2 text-gray-600">현재 담당 아이돌은</span>
-        <Select
-          list={idols}
-          value={currentIdolId}
-          onChange={v => setCurrentIdolId(Number(v))}
-          size="small"
-          className="inline-block min-w-[120px]"
-        />
-        <span className="ml-2 text-gray-600">입니다.</span>
-      </div>
 
       <CalendarScheduleLayout
         dailyMinWidth={420}

--- a/src/pages/main/manager/ManagerMainPage.tsx
+++ b/src/pages/main/manager/ManagerMainPage.tsx
@@ -151,9 +151,9 @@ export default function ManagerMainPage() {
         onClick={handleCreateOpen}
         shape="pill"
         size="lg"
-        className="inline-flex min-w-[185px] items-center justify-center gap-2 bg-fuchsia-100 px-6 font-semibold whitespace-nowrap hover:bg-fuchsia-500 hover:text-white"
+        className="inline-flex h-12 w-[185px] items-center justify-center gap-2 bg-fuchsia-100 px-6 font-semibold whitespace-nowrap hover:bg-fuchsia-500 hover:text-white"
       >
-        <PlusIcon className="h-6 w-6" />
+        <PlusIcon className="h-6 w-6 flex-shrink-0" />
         일정 등록
       </Button>
       <Button
@@ -161,9 +161,9 @@ export default function ManagerMainPage() {
         variant="outline"
         shape="pill"
         size="lg"
-        className="group inline-flex min-w-[185px] items-center justify-center gap-2 border-fuchsia-400 px-6 font-semibold whitespace-nowrap hover:bg-fuchsia-500 hover:text-white"
+        className="group inline-flex h-12 w-[185px] items-center justify-center gap-2 border-fuchsia-400 px-6 font-semibold whitespace-nowrap hover:bg-fuchsia-500 hover:text-white"
       >
-        <ChatBubbleLeftRightIcon className="h-6 w-6 transition-colors group-hover:text-white" />
+        <ChatBubbleLeftRightIcon className="h-6 w-6 flex-shrink-0 transition-colors group-hover:text-white" />
         아이돌과 채팅
       </Button>
     </div>

--- a/src/pages/main/manager/ManagerMainPage.tsx
+++ b/src/pages/main/manager/ManagerMainPage.tsx
@@ -1,0 +1,88 @@
+import { PlusIcon, ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
+import { Button } from '@/components/common/Button';
+import Calendar from '@/components/common/calendar/Calendar';
+import DateScheduleList from '@/components/common/dateSchedule/DateScheduleList';
+import Select from '@/components/common/Select';
+import { CalendarScheduleLayout, Greeting } from '../shared';
+import { useManagerMainData } from './hooks/useManagerMainData';
+
+export default function ManagerMainPage() {
+  const {
+    selectedDate,
+    setSelectedDate,
+    idols,
+    currentIdolId,
+    setCurrentIdolId,
+    filteredSchedules,
+    handleAddClick,
+    handleEditClick,
+    handleDeleteClick,
+  } = useManagerMainData();
+
+  const rightAction = (
+    <div className="mt-6 flex gap-3 lg:ml-6">
+      <Button
+        onClick={handleAddClick}
+        shape="pill"
+        size="lg"
+        className="flex items-center gap-2 bg-fuchsia-100 px-5 font-semibold text-fuchsia-700 hover:bg-fuchsia-200"
+      >
+        <PlusIcon className="h-5 w-5" />
+        일정 등록
+      </Button>
+      <Button
+        onClick={() => alert('아이돌과 채팅으로 이동')}
+        variant="outline"
+        shape="pill"
+        size="lg"
+        className="group flex items-center gap-2 border-fuchsia-400 px-5 font-semibold text-fuchsia-600 hover:bg-fuchsia-400 hover:text-white"
+      >
+        <ChatBubbleLeftRightIcon className="h-5 w-5 text-fuchsia-400 transition-colors group-hover:text-white" />
+        아이돌과 채팅
+      </Button>
+    </div>
+  );
+
+  return (
+    <div className="mx-auto mb-16 max-w-screen-xl px-3 pt-12 md:px-8 lg:mb-24 lg:px-2 lg:pt-6">
+      <Greeting
+        userRole="manager"
+        title="안녕하세요, 매니저 A님!"
+        subtitle="오늘 담당 아티스트의 일정을 관리하세요."
+        rightAction={rightAction}
+      />
+
+      <div className="mb-4 lg:mb-2">
+        <span className="mr-2 text-gray-600">현재 담당 아이돌은</span>
+        <Select
+          list={idols}
+          value={currentIdolId}
+          onChange={v => setCurrentIdolId(Number(v))}
+          size="small"
+          className="inline-block min-w-[120px]"
+        />
+        <span className="ml-2 text-gray-600">입니다.</span>
+      </div>
+
+      <CalendarScheduleLayout
+        dailyMinWidth={420}
+        calendar={
+          <Calendar
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            schedules={filteredSchedules}
+          />
+        }
+        daily={
+          <DateScheduleList
+            userRole="manager"
+            selectedDate={selectedDate.format('YYYY-MM-DD')}
+            schedules={filteredSchedules}
+            onEditClick={handleEditClick}
+            onDeleteClick={handleDeleteClick}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/src/pages/main/manager/ManagerMainPage.tsx
+++ b/src/pages/main/manager/ManagerMainPage.tsx
@@ -5,6 +5,9 @@ import DateScheduleList from '@/components/common/dateSchedule/DateScheduleList'
 import Select from '@/components/common/Select';
 import { CalendarScheduleLayout, Greeting } from '../shared';
 import { useManagerMainData } from './hooks/useManagerMainData';
+import UpsertScheduleModal from './modals/UpsertScheduleModal';
+import DeleteScheduleModal from './modals/DeleteScheduleModal';
+import { useManagerScheduleModals } from './hooks/useManagerScheduleModals';
 
 export default function ManagerMainPage() {
   const {
@@ -14,15 +17,28 @@ export default function ManagerMainPage() {
     currentIdolId,
     setCurrentIdolId,
     filteredSchedules,
-    handleAddClick,
-    handleEditClick,
     handleDeleteClick,
   } = useManagerMainData();
+
+  const {
+    createOpen,
+    editOpen,
+    deleteOpen,
+    targetId,
+    targetTitle,
+    openCreate,
+    closeCreate,
+    openEdit,
+    closeEdit,
+    openDelete,
+    closeDelete,
+    resetTarget,
+  } = useManagerScheduleModals();
 
   const rightAction = (
     <div className="mt-6 flex gap-3 lg:ml-6">
       <Button
-        onClick={handleAddClick}
+        onClick={openCreate}
         shape="pill"
         size="lg"
         className="inline-flex min-w-[185px] items-center justify-center gap-2 bg-fuchsia-100 px-6 font-semibold whitespace-nowrap hover:bg-fuchsia-500 hover:text-white"
@@ -43,6 +59,12 @@ export default function ManagerMainPage() {
       </Button>
     </div>
   );
+
+  const handleOpenDelete = (id: number, title?: string) => {
+    const safeTitle =
+      title ?? filteredSchedules.find(s => s.id === id)?.title ?? '';
+    openDelete(id, safeTitle);
+  };
 
   return (
     <div className="mx-auto mb-16 max-w-screen-xl px-3 pt-12 md:px-8 lg:mb-24 lg:px-2 lg:pt-6">
@@ -80,10 +102,42 @@ export default function ManagerMainPage() {
             userRole="manager"
             selectedDate={selectedDate.format('YYYY-MM-DD')}
             schedules={filteredSchedules}
-            onEditClick={handleEditClick}
-            onDeleteClick={handleDeleteClick}
+            onEditClick={id => openEdit(id)}
+            onDeleteClick={handleOpenDelete}
           />
         }
+      />
+
+      <UpsertScheduleModal
+        open={createOpen}
+        mode="create"
+        onClose={() => {
+          closeCreate();
+          resetTarget();
+        }}
+      />
+      <UpsertScheduleModal
+        open={editOpen}
+        mode="edit"
+        scheduleId={targetId}
+        onClose={() => {
+          closeEdit();
+          resetTarget();
+        }}
+      />
+      <DeleteScheduleModal
+        open={deleteOpen}
+        titleName={targetTitle}
+        onClose={() => {
+          closeDelete();
+          resetTarget();
+        }}
+        onConfirm={() => {
+          if (targetId == null) return;
+          handleDeleteClick(targetId);
+          closeDelete();
+          resetTarget();
+        }}
       />
     </div>
   );

--- a/src/pages/main/manager/hooks/useManagerMainData.ts
+++ b/src/pages/main/manager/hooks/useManagerMainData.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import type { Schedule, IdolSchedule } from '@/types/schedule';
+
+type SelectOption = { id: number; label: string };
+
+export function useManagerMainData() {
+  const [selectedDate, setSelectedDate] = useState<Dayjs>(() => dayjs());
+
+  // TODO: 이후 /api/idols/?page=1 로 교체. 지금은 하드코어 모킹
+  const idols: SelectOption[] = [
+    { id: 201, label: '카리나' },
+    { id: 202, label: '윈터' },
+    { id: 203, label: '닝닝' },
+  ];
+  const [currentIdolId, setCurrentIdolId] = useState<number>(idols[0].id);
+
+  const [allSchedules, setAllSchedules] = useState<Schedule[]>([]);
+
+  useEffect(() => {
+    const iso = selectedDate.format('YYYY-MM-DD');
+
+    // TODO: API 연동: GET /schedules/manager/mainboard/?date=iso&idolId=currentIdolId
+    const mock: IdolSchedule[] = [
+      {
+        id: 1,
+        title: '뮤직뱅크 리허설',
+        startTime: `${iso}T14:00:00`,
+        endTime: `${iso}T15:00:00`,
+        isPublic: true,
+        idol: { id: currentIdolId, name: '선택 아이돌' },
+      },
+      {
+        id: 2,
+        title: '뮤직뱅크 사전녹화',
+        startTime: `${iso}T16:00:00`,
+        endTime: `${iso}T17:00:00`,
+        isPublic: true,
+        idol: { id: currentIdolId, name: '선택 아이돌' },
+      },
+      {
+        id: 3,
+        title: '뮤직뱅크 본방',
+        startTime: `${iso}T18:00:00`,
+        endTime: `${iso}T19:00:00`,
+        isPublic: true,
+        idol: { id: currentIdolId, name: '선택 아이돌' },
+      },
+      {
+        id: 4,
+        title: '팬사인회',
+        startTime: `${iso}T20:00:00`,
+        endTime: `${iso}T21:00:00`,
+        isPublic: true,
+        idol: { id: currentIdolId, name: '선택 아이돌' },
+      },
+    ];
+
+    setAllSchedules(mock as Schedule[]);
+  }, [selectedDate, currentIdolId]);
+
+  const handleAddClick = useCallback(() => {
+    alert('일정 등록 모달 오픈'); // TODO: setOpenCreateModal(true)
+  }, []);
+
+  const handleEditClick = useCallback((id: number) => {
+    alert(`수정 모달 오픈: ${id}`); // TODO: setEditTarget(id); setOpenEditModal(true)
+  }, []);
+
+  const handleDeleteClick = useCallback((id: number) => {
+    // TODO: 실제 삭제 API 연결 전까지 낙관적 업데이트
+    setAllSchedules(prev => prev.filter(s => s.id !== id));
+  }, []);
+
+  const filteredSchedules = useMemo(() => allSchedules, [allSchedules]);
+
+  return {
+    selectedDate,
+    setSelectedDate,
+    idols,
+    currentIdolId,
+    setCurrentIdolId,
+    filteredSchedules,
+    handleAddClick,
+    handleEditClick,
+    handleDeleteClick,
+  };
+}

--- a/src/pages/main/manager/hooks/useManagerMainData.ts
+++ b/src/pages/main/manager/hooks/useManagerMainData.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import type { Schedule, IdolSchedule } from '@/types/schedule';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { IdolSchedule, Schedule } from '@/types/schedule';
 
 type SelectOption = { id: number; label: string };
 

--- a/src/pages/main/manager/hooks/useManagerScheduleModals.ts
+++ b/src/pages/main/manager/hooks/useManagerScheduleModals.ts
@@ -1,0 +1,46 @@
+import { useState, useCallback } from 'react';
+
+export function useManagerScheduleModals() {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const [targetId, setTargetId] = useState<number | null>(null);
+  const [targetTitle, setTargetTitle] = useState<string>('');
+
+  const openCreate = useCallback(() => setCreateOpen(true), []);
+  const closeCreate = useCallback(() => setCreateOpen(false), []);
+
+  const openEdit = useCallback((id: number) => {
+    setTargetId(id);
+    setEditOpen(true);
+  }, []);
+  const closeEdit = useCallback(() => setEditOpen(false), []);
+
+  const openDelete = useCallback((id: number, title: string) => {
+    setTargetId(id);
+    setTargetTitle(title);
+    setDeleteOpen(true);
+  }, []);
+  const closeDelete = useCallback(() => setDeleteOpen(false), []);
+
+  const resetTarget = useCallback(() => {
+    setTargetId(null);
+    setTargetTitle('');
+  }, []);
+
+  return {
+    createOpen,
+    editOpen,
+    deleteOpen,
+    targetId,
+    targetTitle,
+    openCreate,
+    closeCreate,
+    openEdit,
+    closeEdit,
+    openDelete,
+    closeDelete,
+    resetTarget,
+  };
+}

--- a/src/pages/main/manager/hooks/useManagerScheduleModals.ts
+++ b/src/pages/main/manager/hooks/useManagerScheduleModals.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 export function useManagerScheduleModals() {
   const [createOpen, setCreateOpen] = useState(false);

--- a/src/pages/main/manager/modals/DeleteScheduleModal.tsx
+++ b/src/pages/main/manager/modals/DeleteScheduleModal.tsx
@@ -1,0 +1,24 @@
+import DeleteModal from '@/components/common/modal/DeleteModal';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  titleName: string;
+};
+
+export default function DeleteScheduleModal({
+  open,
+  onClose,
+  onConfirm,
+  titleName,
+}: Props) {
+  return (
+    <DeleteModal
+      isOpen={open}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      itemToDeleteName={titleName}
+    />
+  );
+}

--- a/src/pages/main/manager/modals/UpsertScheduleModal.tsx
+++ b/src/pages/main/manager/modals/UpsertScheduleModal.tsx
@@ -24,16 +24,19 @@ export default function UpsertScheduleModal({
   onClose,
   onSubmit,
   initialValues,
+  scheduleId,
 }: Props) {
   const title = mode === 'create' ? '일정 등록' : '일정 수정';
 
   return (
-    <ScheduleFormModal
-      isOpen={open}
-      onClose={onClose}
-      title={title}
-      onSubmit={onSubmit}
-      initialValues={initialValues}
-    />
+    <div data-schedule-id={scheduleId ?? undefined}>
+      <ScheduleFormModal
+        isOpen={open}
+        onClose={onClose}
+        title={title}
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+      />
+    </div>
   );
 }

--- a/src/pages/main/manager/modals/UpsertScheduleModal.tsx
+++ b/src/pages/main/manager/modals/UpsertScheduleModal.tsx
@@ -1,0 +1,16 @@
+import ScheduleFormModal from '@/components/common/modal/ScheduleFormModal';
+
+type Props = {
+  open: boolean;
+  mode: 'create' | 'edit';
+  onClose: () => void;
+  // 추후 API 연동시 사용 예정
+  onSubmit?: (form: unknown) => Promise<void> | void;
+  scheduleId?: number | null;
+};
+
+export default function UpsertScheduleModal({ open, mode, onClose }: Props) {
+  const title = mode === 'create' ? '일정 등록' : '일정 수정';
+
+  return <ScheduleFormModal isOpen={open} onClose={onClose} title={title} />;
+}

--- a/src/pages/main/manager/modals/UpsertScheduleModal.tsx
+++ b/src/pages/main/manager/modals/UpsertScheduleModal.tsx
@@ -1,16 +1,39 @@
 import ScheduleFormModal from '@/components/common/modal/ScheduleFormModal';
 
+type ScheduleFormValues = {
+  title: string;
+  date: string;
+  time: string;
+  place: string;
+  description: string;
+  isPublic: boolean;
+};
+
 type Props = {
   open: boolean;
   mode: 'create' | 'edit';
   onClose: () => void;
-  // 추후 API 연동시 사용 예정
-  onSubmit?: (form: unknown) => Promise<void> | void;
+  onSubmit?: (values: ScheduleFormValues) => void | Promise<void>;
+  initialValues?: Partial<ScheduleFormValues>;
   scheduleId?: number | null;
 };
 
-export default function UpsertScheduleModal({ open, mode, onClose }: Props) {
+export default function UpsertScheduleModal({
+  open,
+  mode,
+  onClose,
+  onSubmit,
+  initialValues,
+}: Props) {
   const title = mode === 'create' ? '일정 등록' : '일정 수정';
 
-  return <ScheduleFormModal isOpen={open} onClose={onClose} title={title} />;
+  return (
+    <ScheduleFormModal
+      isOpen={open}
+      onClose={onClose}
+      title={title}
+      onSubmit={onSubmit}
+      initialValues={initialValues}
+    />
+  );
 }

--- a/src/pages/main/shared/sections/Greeting.tsx
+++ b/src/pages/main/shared/sections/Greeting.tsx
@@ -31,14 +31,14 @@ function Greeting({
               {title}
             </h1>
             {subtitle && (
-              <p
+              <div
                 className={clsx(
                   'mt-2 text-lg text-gray-500',
                   subtitleClassName,
                 )}
               >
                 {subtitle}
-              </p>
+              </div>
             )}
           </div>
         </div>
@@ -62,9 +62,9 @@ function Greeting({
             </h1>
           </div>
           {subtitle && (
-            <p className={clsx('text-lg text-gray-600', subtitleClassName)}>
+            <div className={clsx('text-lg text-gray-600', subtitleClassName)}>
               {subtitle}
-            </p>
+            </div>
           )}
         </div>
         {rightAction && (

--- a/src/pages/main/shared/sections/Greeting.tsx
+++ b/src/pages/main/shared/sections/Greeting.tsx
@@ -14,7 +14,7 @@ function Greeting({
     <header className="mb-8">
       {/* Desktop */}
       <div className="hidden items-center justify-between gap-6 lg:flex">
-        <div className="flex min-w-0 flex-1 items-center gap-3 pt-11 pb-16">
+        <div className="flex min-w-0 flex-1 items-center gap-3 pt-11 pb-10">
           {leftIcon && (
             <div className={clsx('self-center', leftIconClassName)}>
               {leftIcon}
@@ -32,7 +32,7 @@ function Greeting({
             {subtitle && (
               <p
                 className={clsx(
-                  'mt-1 text-lg text-gray-500',
+                  'mt-2 text-lg text-gray-500',
                   subtitleClassName,
                 )}
               >
@@ -48,12 +48,23 @@ function Greeting({
       <div className="lg:hidden">
         <div className="mb-1 text-center">
           <div className="mb-2 flex flex-col items-center justify-center gap-2">
-            {leftIcon}
-            <h1 className="text-3xl leading-snug font-bold whitespace-pre-line">
+            {leftIcon && (
+              <div className={clsx(leftIconClassName)}>{leftIcon}</div>
+            )}
+            <h1
+              className={clsx(
+                'text-3xl leading-snug font-bold whitespace-pre-line',
+                titleClassName,
+              )}
+            >
               {title}
             </h1>
           </div>
-          {subtitle && <p className="text-lg text-gray-600">{subtitle}</p>}
+          {subtitle && (
+            <p className={clsx('text-lg text-gray-600', subtitleClassName)}>
+              {subtitle}
+            </p>
+          )}
         </div>
         {rightAction && (
           <div className="flex justify-center">{rightAction}</div>

--- a/src/pages/main/shared/sections/Greeting.tsx
+++ b/src/pages/main/shared/sections/Greeting.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+
 import type { GreetingProps } from '../types';
 
 function Greeting({

--- a/src/pages/main/shared/sections/Greeting.tsx
+++ b/src/pages/main/shared/sections/Greeting.tsx
@@ -50,7 +50,15 @@ function Greeting({
         <div className="mb-1 text-center">
           <div className="mb-2 flex flex-col items-center justify-center gap-2">
             {leftIcon && (
-              <div className={clsx(leftIconClassName)}>{leftIcon}</div>
+              <div
+                className={clsx(
+                  'mx-auto flex h-10 w-10 items-center justify-center',
+                  'leading-none',
+                  leftIconClassName,
+                )}
+              >
+                <div className="block">{leftIcon}</div>
+              </div>
             )}
             <h1
               className={clsx(

--- a/src/pages/main/shared/sections/Greeting.tsx
+++ b/src/pages/main/shared/sections/Greeting.tsx
@@ -1,17 +1,44 @@
+import clsx from 'clsx';
 import type { GreetingProps } from '../types';
 
-function Greeting({ title, subtitle, leftIcon, rightAction }: GreetingProps) {
+function Greeting({
+  title,
+  subtitle,
+  leftIcon,
+  rightAction,
+  titleClassName,
+  subtitleClassName,
+  leftIconClassName,
+}: GreetingProps) {
   return (
     <header className="mb-8">
-      {/* Desktop (lg 이상) */}
+      {/* Desktop */}
       <div className="hidden items-center justify-between gap-6 lg:flex">
         <div className="flex min-w-0 flex-1 items-center gap-3 pt-11 pb-16">
-          {leftIcon}
+          {leftIcon && (
+            <div className={clsx('self-center', leftIconClassName)}>
+              {leftIcon}
+            </div>
+          )}
           <div className="min-w-0">
-            <h1 className="truncate text-4xl font-bold whitespace-nowrap text-gray-900">
+            <h1
+              className={clsx(
+                'truncate text-4xl font-bold whitespace-nowrap text-gray-900',
+                titleClassName,
+              )}
+            >
               {title}
             </h1>
-            {subtitle && <p className="mt-1 text-gray-500">{subtitle}</p>}
+            {subtitle && (
+              <p
+                className={clsx(
+                  'mt-1 text-lg text-gray-500',
+                  subtitleClassName,
+                )}
+              >
+                {subtitle}
+              </p>
+            )}
           </div>
         </div>
         {rightAction}

--- a/src/pages/main/shared/types.ts
+++ b/src/pages/main/shared/types.ts
@@ -6,6 +6,9 @@ export type GreetingProps = {
   subtitle?: string;
   leftIcon?: React.ReactNode;
   rightAction?: React.ReactNode;
+  titleClassName?: string;
+  subtitleClassName?: string;
+  leftIconClassName?: string;
 };
 
 export type CalendarScheduleLayoutProps = {

--- a/src/pages/main/shared/types.ts
+++ b/src/pages/main/shared/types.ts
@@ -3,7 +3,7 @@ export type MainRole = 'fan' | 'idol' | 'manager';
 export type GreetingProps = {
   userRole: MainRole;
   title: string;
-  subtitle?: string;
+  subtitle?: React.ReactNode;
   leftIcon?: React.ReactNode;
   rightAction?: React.ReactNode;
   titleClassName?: string;

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -7,6 +7,7 @@ interface BaseSchedule {
   isPublic: boolean;
   isBookmarked?: boolean;
   isNotified?: boolean;
+  place?: string;
 }
 
 interface GroupInfo {

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -8,6 +8,7 @@ interface BaseSchedule {
   isBookmarked?: boolean;
   isNotified?: boolean;
   place?: string;
+  location?: string;
 }
 
 interface GroupInfo {


### PR DESCRIPTION
# ✨ 역할별 메인 페이지 구현 (아이돌/매니저)

## 🚀 PR 요약

아이돌 메인 페이지와 매니저 메인 페이지를 구현했습니다.  
추가적으로 모달에 **제목을 표시하는 UI**를 넣었고, 일단 현재는 **목업데이터 기반**으로 동작하도록 작성되어 있습니다.  
또한, **DateScheduleItem 간격을 조정**하여 글씨 잘림/간격 문제를 개선했습니다.  

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가  
- [x] style: 레이아웃/간격 조정  
- [x] refactor: 린트 규칙 준수 및 일부 코드 정리  

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.  
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.  
- [x] 실행에 문제가 없는지 테스트했습니다.  
- [x] 이슈 브랜치 -> develop PR은 **squash and merge**, develop -> main PR은 **rebase and merge**를 선택했습니다.  

```
## 📂 주요 변경 폴더 구조
```
src/
├─&nbsp;pages/
│&nbsp;&nbsp;&nbsp;└─&nbsp;main/
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├─&nbsp;idol/
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;├─&nbsp;IdolMainPage.tsx
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;└─&nbsp;hooks/useIdolMainData.ts
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─&nbsp;manager/
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├─&nbsp;ManagerMainPage.tsx
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├─&nbsp;hooks/useManagerMainData.ts
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├─&nbsp;hooks/useManagerScheduleModals.ts
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─&nbsp;modals/
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├─&nbsp;UpsertScheduleModal.tsx
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─&nbsp;DeleteScheduleModal.tsx
├─&nbsp;components/
│&nbsp;&nbsp;&nbsp;└─&nbsp;common/
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─&nbsp;modal/
│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─&nbsp;ScheduleFormModal.tsx

```
```

## 📸 스크린샷
### 아이돌 메인 페이지
- 데스크탑  
  > <img width="1702" height="844" alt="아이돌_데스크" src="https://github.com/user-attachments/assets/fc38e7b1-0420-4569-8816-9d294d447709" />


- 모바일  
  > ![아이돌_모바일 mp4](https://github.com/user-attachments/assets/d0845f51-4cdf-4298-9762-2fafad856dad)


### 매니저 메인 페이지
- 데스크탑  
  > <img width="1697" height="859" alt="매니저_데스크" src="https://github.com/user-attachments/assets/748b86bc-7766-461a-846e-13a0a371093d" />


- 모바일  
 >  ![Vite + React + TS mp4](https://github.com/user-attachments/assets/25c77ded-00b5-4f09-b833-f47382867967)


## 🛠️ 구현 상세
- 아이돌 메인 페이지 구현  
- 매니저 메인 페이지 구현  
- 공통 컴포넌트 역할별 분기 처리  
- 각 역할별 전용 훅 구현  
- ESLint 규칙 준수  


## 🔑 핵심 함수/훅 요약

- `useIdolMainData` : 아이돌 메인 스케줄 관리 훅  
- `useManagerMainData` : 매니저 메인 스케줄 CRUD 훅  
- `useManagerScheduleModals` : 매니저 모달 열림/닫힘 제어 훅  
- `ScheduleFormModal` : 일정 등록/수정 모달 (제목 추가)  
- `DateScheduleItem` : 리스트 항목 레이아웃 개선 (시간-타이틀 간격 수정)  

## 🗒️ 기타 참고사항

- 현재 API 연결 전 단계라 **목업데이터 기반**입니다.  
- 모바일/데스크탑 레이아웃은 기본적으로 확인 완료, 추가적인 보정은 필요할 수 있습니다.  

## 🔗 연관된 이슈

closes #134
