### PR TITLE
Feat: 비밀번호 수정 탭 ui 추가

### DIFF
--- a/src/components/mypage/PasswordEdit.tsx
+++ b/src/components/mypage/PasswordEdit.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@/components/common/Button';
+import Input from '@/components/common/input';
+
+interface PasswordEditProps {
+  onCancelEdit: () => void;
+}
+
+export default function PasswordEdit({ onCancelEdit }: PasswordEditProps) {
+  return (
+    <div className="w-full flex-1 rounded-2xl border border-gray-200 bg-white p-6 shadow-md md:p-10">
+      <h2 className="mb-6 text-2xl font-semibold">비밀번호 수정</h2>
+      <form className="flex flex-col gap-4">
+        <Input type="password" label="현재 비밀번호" />
+        <Input type="password" label="새 비밀번호" />
+        <Input type="password" label="새 비밀번호 확인" />
+
+        <div className="mt-6 flex justify-end gap-3">
+          <Button type="button" variant="secondary" onClick={onCancelEdit}>
+            취소
+          </Button>
+          <Button type="submit">저장</Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/mypage/ProfileEdit.tsx
+++ b/src/components/mypage/ProfileEdit.tsx
@@ -14,9 +14,13 @@ import { toastFormErrors } from '@/utils/toastUtils';
 
 interface ProfileEditProps {
   onCancelEdit: () => void;
+  onSwitchToPasswordEdit: () => void;
 }
 
-export default function ProfileEdit({ onCancelEdit }: ProfileEditProps) {
+export default function ProfileEdit({
+  onCancelEdit,
+  onSwitchToPasswordEdit,
+}: ProfileEditProps) {
   const { user } = useUserStore();
   const { submit, isLoading } = useProfileEdit({ onCancelEdit });
 
@@ -56,7 +60,11 @@ export default function ProfileEdit({ onCancelEdit }: ProfileEditProps) {
         <Input type="text" label="닉네임" {...register('nickname')} />
 
         <div>
-          <button type="button" className="hover:underline">
+          <button
+            type="button"
+            className="hover:underline"
+            onClick={onSwitchToPasswordEdit}
+          >
             비밀번호 수정
           </button>
 

--- a/src/components/mypage/ProfileEdit.tsx
+++ b/src/components/mypage/ProfileEdit.tsx
@@ -34,7 +34,7 @@ export default function ProfileEdit({ onCancelEdit }: ProfileEditProps) {
       <h2 className="mb-6 text-2xl font-semibold">프로필 수정</h2>
       <form
         onSubmit={handleSubmit(submit, toastFormErrors)}
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-6"
       >
         <div className="flex flex-col items-center gap-4">
           <UserAvatarImage
@@ -55,18 +55,24 @@ export default function ProfileEdit({ onCancelEdit }: ProfileEditProps) {
         />
         <Input type="text" label="닉네임" {...register('nickname')} />
 
-        <div className="mt-6 flex justify-end gap-3">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={onCancelEdit}
-            disabled={isLoading}
-          >
-            취소
-          </Button>
-          <Button type="submit" disabled={isLoading}>
-            저장
-          </Button>
+        <div>
+          <button type="button" className="hover:underline">
+            비밀번호 수정
+          </button>
+
+          <div className="mt-6 flex justify-end gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onCancelEdit}
+              disabled={isLoading}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              저장
+            </Button>
+          </div>
         </div>
       </form>
     </div>

--- a/src/pages/MyProfile.tsx
+++ b/src/pages/MyProfile.tsx
@@ -1,22 +1,47 @@
 import { useState } from 'react';
 
 // import FavoriteIdols from '@/components/mypage/FavoriteIdols';
+import PasswordEdit from '@/components/mypage/PasswordEdit';
 import Profile from '@/components/mypage/Profile';
 import ProfileEdit from '@/components/mypage/ProfileEdit';
 
-export default function MyProfile() {
-  const [isEditingProfile, setIsEditingProfile] = useState(false);
+type ProfileViewMode = 'view' | 'edit' | 'password_edit';
 
-  const toggleEditMode = () => {
-    setIsEditingProfile(prev => !prev);
+export default function MyProfile() {
+  const [currentView, setCurrentView] = useState<ProfileViewMode>('view');
+
+  const handleSwitchToEdit = () => {
+    setCurrentView('edit');
   };
 
-  return isEditingProfile ? (
-    <ProfileEdit onCancelEdit={toggleEditMode} />
-  ) : (
-    <>
-      <Profile onEditClick={toggleEditMode} />
-      {/* <FavoriteIdols /> */}
-    </>
-  );
+  const handleSwitchToPasswordEdit = () => {
+    setCurrentView('password_edit');
+  };
+
+  const handleCancelEdit = () => {
+    setCurrentView('view');
+  };
+
+  const renderView = () => {
+    switch (currentView) {
+      case 'view':
+        return (
+          <Profile onEditClick={handleSwitchToEdit} />
+          // <FavoriteIdols />
+        );
+      case 'edit':
+        return (
+          <ProfileEdit
+            onCancelEdit={handleCancelEdit}
+            onSwitchToPasswordEdit={handleSwitchToPasswordEdit}
+          />
+        );
+      case 'password_edit':
+        return <PasswordEdit onCancelEdit={handleCancelEdit} />;
+      default:
+        return null;
+    }
+  };
+
+  return <>{renderView()}</>;
 }


### PR DESCRIPTION
## 🚀 PR 요약

비밀번호 수정 탭 ui 추가

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

프로필 수정 탭에 '비밀번호 수정' 버튼 추가
<img width="1013" height="641" alt="image" src="https://github.com/user-attachments/assets/53e2d557-2eaf-4d91-b406-009ef9d49a24" />

클릭 시 비밀번호 수정 탭 전환
<img width="1002" height="589" alt="image" src="https://github.com/user-attachments/assets/67eda10c-6edf-4fa5-9307-fe18394702c0" />

## 🔗 연관된 이슈

> closes #152 
