### PR TITLE
Refactor: favoritesStore persist 제거 및 검색 페이지 안내 문구 간격 조정

### DIFF
--- a/src/pages/idolSearch/IdolSearchPage.tsx
+++ b/src/pages/idolSearch/IdolSearchPage.tsx
@@ -65,7 +65,7 @@ export default function IdolSearchPage() {
         {isError && <ErrorMessage />}
 
         {!isLoading && !isError && shouldShowEmptyFavorites && (
-          <div className="mt-auto mb-16 md:mb-10">
+          <div className="mt-12 mb-14 md:mt-10 md:mb-20">
             <FavoriteEmptyState />
           </div>
         )}

--- a/src/stores/favoritesStore.ts
+++ b/src/stores/favoritesStore.ts
@@ -1,26 +1,22 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 interface FavoritesState {
   favorites: string[];
   toggleFavorite: (idolId: string) => void;
   isFavorited: (idolId: string) => boolean;
+  setFavorites: (ids: string[]) => void;
+  clear: () => void;
 }
 
-export const useFavoritesStore = create<FavoritesState>()(
-  persist(
-    (set, get) => ({
-      favorites: [],
-      toggleFavorite: (idolId: string) =>
-        set(state => ({
-          favorites: state.favorites.includes(idolId)
-            ? state.favorites.filter(id => id !== idolId)
-            : [...state.favorites, idolId],
-        })),
-      isFavorited: (idolId: string) => get().favorites.includes(idolId),
-    }),
-    {
-      name: 'favorites-storage',
-    },
-  ),
-);
+export const useFavoritesStore = create<FavoritesState>()((set, get) => ({
+  favorites: [],
+  toggleFavorite: idolId =>
+    set(s => ({
+      favorites: s.favorites.includes(idolId)
+        ? s.favorites.filter(id => id !== idolId)
+        : [...s.favorites, idolId],
+    })),
+  isFavorited: idolId => get().favorites.includes(idolId),
+  setFavorites: ids => set({ favorites: Array.from(new Set(ids)) }),
+  clear: () => set({ favorites: [] }),
+}));


### PR DESCRIPTION
## 🚀 PR 요약

> favoritesStore에서 persist를 제거하여 로컬스토리지 중복 저장 문제를 해소하고,  
> 검색 페이지 빈 상태 안내 문구의 간격을 조정했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링
- [x] style: 코드 포맷팅 등 스타일 변경

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.
- [x] 이슈 브랜치 -> develop PR은 **squash and merge**, develop -> main PR은 **rebase and merge**를 선택했습니다.

## 🗒️ 기타 참고사항

- `favoritesStore.ts`에서 persist를 제거 → 목업 API와의 중복 저장 키 문제 해결  
- `setFavorites`, `clear` 메서드 추가로 API 연동 시 서버 데이터 동기화 대비  
- 검색 페이지의 빈 상태 안내 문구 상·하단 간격을 조정하여 긴 화면에서도 어색하지 않게 개선  

간단한 수정 작업이므로 이상 없으시면 이모지 남겨주시면 바로 머지하겠습니다.

## 📸 스크린샷
###Before (zustand persist랑 목업데이터 로컬스토리지 키 값 2개)
<img width="1723" height="804" alt="스크린샷 2025-08-24 오후 9 37 40" src="https://github.com/user-attachments/assets/1549ba16-ffb9-4653-acfa-553503a9e243" />

###After (목업데이터의 로컬스토리지 키 값만 생성)
<img width="1719" height="806" alt="스크린샷 2025-08-24 오후 10 29 33" src="https://github.com/user-attachments/assets/db0836c7-0c4d-44bb-ae46-d159cddba1b0" />

###Before (검색바 밑부분 문구랑 간격)
<img width="989" height="950" alt="스크린샷 2025-08-24 오후 9 39 53" src="https://github.com/user-attachments/assets/5f170cd8-6b51-4134-a859-42c3d0a461c2" />

###After (현재 전체화면)
<img width="1710" height="946" alt="스크린샷 2025-08-24 오후 10 41 37" src="https://github.com/user-attachments/assets/2724c1b3-f16e-4d8a-adf0-b62138ed5f88" />



## 🔗 연관된 이슈

> closes #156
