### PR TITLE
Refactor: 랜딩 페이지 애니메이션 추가

### DIFF
--- a/src/pages/landing/sections/Hero.tsx
+++ b/src/pages/landing/sections/Hero.tsx
@@ -1,31 +1,68 @@
+import { motion } from 'framer-motion';
+
 import { Button } from '@/components/common/Button';
 import { usePageNav } from '@/hooks/usePageNav';
 
 function Hero() {
   const { navigateToLogin } = usePageNav();
 
+  const container = {
+    hidden: {},
+    show: {
+      transition: {
+        staggerChildren: 0.3,
+        delayChildren: 0.3,
+      },
+    },
+  };
+
+  const item = {
+    hidden: { opacity: 0, y: -30 },
+    show: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.8,
+      },
+    },
+  };
+
   return (
     <div className="bg-[url(@/assets/images/placeholder-lg.jpg)] bg-cover bg-center bg-no-repeat">
-      <div className="flex flex-col items-center gap-8 bg-white/15 px-[2.5%] py-24 text-white md:p-24">
-        <h1 className="flex flex-col gap-4 text-center text-4xl font-bold tracking-tight break-keep sm:text-5xl xl:flex-row xl:gap-0">
+      <motion.div
+        variants={container}
+        initial="hidden"
+        whileInView="show"
+        viewport={{ once: true }}
+        className="flex flex-col items-center gap-8 bg-white/15 px-[2.5%] py-24 text-white md:p-24"
+      >
+        <motion.h1
+          variants={item}
+          className="flex flex-col gap-4 text-center text-4xl font-bold tracking-tight break-keep sm:text-5xl xl:flex-row xl:gap-0"
+        >
           <span className="hidden xl:block">최애 아이돌의 스케줄,&nbsp;</span>
           <span className="block xl:hidden">최애 아이돌의 스케줄</span>
           <span>딩딩이 알려드릴게요</span>
-        </h1>
-        <div className="text-center text-sm/7 font-medium sm:text-base/7">
+        </motion.h1>
+        <motion.div
+          variants={item}
+          className="text-center text-sm/7 font-medium sm:text-base/7"
+        >
           <p>최애 아이돌의 스케줄이 궁금하신가요?</p>
           <p>딩딩이 최애 아이돌의 공개 스케줄을 미리 알아보고</p>
           <p>놓치지 않도록 알림으로 알려드릴게요.</p>
-        </div>
-        <Button
-          variant="primary"
-          size="lg"
-          shape="pill"
-          onClick={navigateToLogin}
-        >
-          시작하기
-        </Button>
-      </div>
+        </motion.div>
+        <motion.div variants={item}>
+          <Button
+            variant="primary"
+            size="lg"
+            shape="pill"
+            onClick={navigateToLogin}
+          >
+            시작하기
+          </Button>
+        </motion.div>
+      </motion.div>
     </div>
   );
 }

--- a/src/pages/landing/sections/RoleCards.tsx
+++ b/src/pages/landing/sections/RoleCards.tsx
@@ -1,3 +1,5 @@
+import { motion, useAnimation } from 'framer-motion';
+
 import Card from '@/components/common/card';
 
 const ROLE_CARDS = [
@@ -19,19 +21,34 @@ const ROLE_CARDS = [
 ];
 
 function RoleCards() {
+  const controls = useAnimation();
+
   return (
-    <div className="m-auto flex max-w-screen-xl flex-col items-center gap-18 px-4 py-24">
-      <h4 className="text-center text-2xl font-bold">
+    <div className="m-auto flex max-w-screen-xl flex-col items-center gap-18 px-4 py-50">
+      <motion.h4
+        animate={controls}
+        initial={{ opacity: 0, y: -50 }}
+        transition={{ duration: 0.8 }}
+        className="text-center text-2xl font-bold"
+      >
         팬·매니저·아이돌, 딩딩이 하나로 연결해 드려요
-      </h4>
+      </motion.h4>
       <div className="flex scale-100 flex-col gap-8 sm:scale-65 sm:flex-row md:scale-78 lg:scale-100">
-        {ROLE_CARDS.map(({ id, title, description }) => (
-          <Card
-            key={id}
-            type="animation"
-            title={title}
-            description={description}
-          />
+        {ROLE_CARDS.map(({ id, title, description }, idx) => (
+          <motion.div
+            initial={{ opacity: 0, y: -50 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 0.3 * (idx + 1) }}
+            viewport={{ once: true, amount: 1 }}
+            onViewportEnter={() => controls.start({ opacity: 1, y: 0 })}
+          >
+            <Card
+              key={id}
+              type="animation"
+              title={title}
+              description={description}
+            />
+          </motion.div>
         ))}
       </div>
     </div>

--- a/src/pages/landing/sections/RoleCards.tsx
+++ b/src/pages/landing/sections/RoleCards.tsx
@@ -24,7 +24,7 @@ function RoleCards() {
   const controls = useAnimation();
 
   return (
-    <div className="m-auto flex max-w-screen-xl flex-col items-center gap-18 px-4 py-50">
+    <div className="m-auto flex max-w-screen-xl flex-col items-center gap-24 px-4 py-60">
       <motion.h4
         animate={controls}
         initial={{ opacity: 0, y: -50 }}
@@ -36,18 +36,14 @@ function RoleCards() {
       <div className="flex scale-100 flex-col gap-8 sm:scale-65 sm:flex-row md:scale-78 lg:scale-100">
         {ROLE_CARDS.map(({ id, title, description }, idx) => (
           <motion.div
+            key={id}
             initial={{ opacity: 0, y: -50 }}
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.3 * (idx + 1) }}
             viewport={{ once: true, amount: 1 }}
             onViewportEnter={() => controls.start({ opacity: 1, y: 0 })}
           >
-            <Card
-              key={id}
-              type="animation"
-              title={title}
-              description={description}
-            />
+            <Card type="animation" title={title} description={description} />
           </motion.div>
         ))}
       </div>


### PR DESCRIPTION
## 🚀 PR 요약

사용자 경험 향상을 위해 framer-motion을 이용해 랜딩 페이지 요소에 애니메이션 스타일을 추가했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

### 작업 사항
- Hero Banner에 fade-in-up 애니메이션 추가
- Role Cards에 fade-in-up 애니메이션 추가

### 스크린샷
![ViteReactTS-Chrome2025-08-2511-43-30-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/e6e3190a-6026-4b9d-8598-b25ada09f90a)


## 🔗 연관된 이슈

> closes #160
