### PR TITLE
Feat: 아이돌 검색 API 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 .vite
+
+.env.local

--- a/src/api/idolApi.ts
+++ b/src/api/idolApi.ts
@@ -27,8 +27,9 @@ export type Idol = {
 
 const toAbsolute = (url: string) => {
   if (/^https?:\/\//i.test(url)) return url;
-  const base = import.meta.env.VITE_API_TARGET_URL ?? '';
-  return base.replace(/\/$/, '') + '/' + url.replace(/^\//, '');
+  const base = (import.meta.env.VITE_API_TARGET_URL ?? '').replace(/\/+$/, '');
+  const path = url.replace(/^\/+/, '');
+  return `${base}/${path}`;
 };
 
 export async function searchIdolsApi(

--- a/src/api/idolApi.ts
+++ b/src/api/idolApi.ts
@@ -1,0 +1,64 @@
+import axiosInstance from '@/api/axiosInstance';
+
+type DRFPage<T> = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+};
+
+type IdolServer = {
+  id: number;
+  name: string;
+  user: number;
+  group: number | null;
+  created_at: string;
+  updated_at: string;
+  avatar_url?: string | null;
+};
+
+export type Idol = {
+  id: string;
+  name: string;
+  groupName?: string;
+  avatarUrl?: string;
+  position?: '보컬' | '댄서' | '랩';
+};
+
+const toAbsolute = (url: string) => {
+  if (/^https?:\/\//i.test(url)) return url;
+  const base = import.meta.env.VITE_API_TARGET_URL ?? '';
+  return base.replace(/\/$/, '') + '/' + url.replace(/^\//, '');
+};
+
+export async function searchIdolsApi(
+  q: string,
+  page: number,
+): Promise<{ items: Idol[]; nextPage?: number }> {
+  const res = await axiosInstance.get<DRFPage<IdolServer>>('/idols/', {
+    params: { search: q, page },
+  });
+
+  const { results, next } = res.data;
+
+  const items: Idol[] = results.map(it => {
+    const raw = typeof it.avatar_url === 'string' ? it.avatar_url.trim() : '';
+    const serverUrl = raw ? toAbsolute(raw) : undefined;
+    const fallback = `https://api.dicebear.com/8.x/fun-emoji/svg?seed=${encodeURIComponent(
+      it.name,
+    )}`;
+
+    return {
+      id: String(it.id),
+      name: it.name,
+      avatarUrl: serverUrl ?? fallback,
+      groupName: (it as any).group_name ?? '', // 아직 없어서 빈값
+      position: (it as any).position ?? '', // 나중에 서버가 주면 자동 반영
+    };
+  });
+
+  return {
+    items,
+    nextPage: next ? page + 1 : undefined,
+  };
+}

--- a/src/components/mypage/PasswordEdit.tsx
+++ b/src/components/mypage/PasswordEdit.tsx
@@ -5,8 +5,8 @@ import { Button } from '@/components/common/Button';
 import Input from '@/components/common/input';
 import { usePasswordEdit } from '@/hooks/usePasswordEdit';
 import {
-  PasswordChangeSchema,
   type PasswordChangeFormValues,
+  PasswordChangeSchema,
 } from '@/schemas/passwordSchema';
 import { handleEnterKey } from '@/utils/handleEnterKey';
 import { toastFormErrors } from '@/utils/toastUtils';

--- a/src/hooks/usePasswordEdit.ts
+++ b/src/hooks/usePasswordEdit.ts
@@ -1,9 +1,9 @@
+import axios from 'axios';
 import { useState } from 'react';
 
-import axios from 'axios';
-import { showErrorToast, showSuccessToast } from '@/utils/toastUtils';
 import { changePassword, verifyCurrentPassword } from '@/api/userApi';
 import { type NewPasswordFormValues } from '@/schemas/passwordSchema';
+import { showErrorToast, showSuccessToast } from '@/utils/toastUtils';
 
 interface UsePasswordEditProps {
   onCancelEdit: () => void;

--- a/src/pages/idolSearch/IdolSearchList.tsx
+++ b/src/pages/idolSearch/IdolSearchList.tsx
@@ -1,9 +1,9 @@
 import { VirtuosoGrid } from 'react-virtuoso';
 
+import type { Idol } from '@/api/idolApi';
 import Card from '@/components/common/card';
 
 import GridFooter from './components/GridFooter';
-import type { Idol } from '@/api/idolApi';
 
 type Props = {
   idols: Idol[];

--- a/src/pages/idolSearch/IdolSearchList.tsx
+++ b/src/pages/idolSearch/IdolSearchList.tsx
@@ -3,7 +3,7 @@ import { VirtuosoGrid } from 'react-virtuoso';
 import Card from '@/components/common/card';
 
 import GridFooter from './components/GridFooter';
-import type { Idol } from './useIdolSearch';
+import type { Idol } from '@/api/idolApi';
 
 type Props = {
   idols: Idol[];
@@ -29,7 +29,10 @@ export default function IdolSearchList({
         idolId={idol.id}
         title={idol.name}
         imageSrc={idol.avatarUrl || ''}
-        detail={{ idolGroup: idol.groupName, position: idol.position }}
+        detail={{
+          idolGroup: idol.groupName ?? '',
+          position: idol.position ?? '',
+        }}
         onClick={() => onCardClick(idol.id)}
       />
     </div>

--- a/src/pages/idolSearch/useIdolSearch.ts
+++ b/src/pages/idolSearch/useIdolSearch.ts
@@ -6,13 +6,14 @@ import {
 } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
-import { useSyncArrayData } from '@/hooks/useSyncArrayData';
 import { searchIdolsApi } from '@/api/idolApi';
+import { useSyncArrayData } from '@/hooks/useSyncArrayData';
 import {
   fetchFavoriteIdols,
   toggleFavorite as mockToggleFavorite,
 } from '@/mocks/data/idols';
 import { useFavoritesStore } from '@/stores/favoritesStore';
+
 export function useIdolSearch(debouncedSearchQuery: string) {
   const queryClient = useQueryClient();
   const { favorites, toggleFavorite } = useFavoritesStore();

--- a/src/pages/idolSearch/useIdolSearch.ts
+++ b/src/pages/idolSearch/useIdolSearch.ts
@@ -7,23 +7,12 @@ import {
 import { useMemo } from 'react';
 
 import { useSyncArrayData } from '@/hooks/useSyncArrayData';
+import { searchIdolsApi } from '@/api/idolApi';
 import {
   fetchFavoriteIdols,
-  searchIdols,
   toggleFavorite as mockToggleFavorite,
 } from '@/mocks/data/idols';
 import { useFavoritesStore } from '@/stores/favoritesStore';
-
-export type Idol = {
-  id: string;
-  name: string;
-  groupName: string;
-  avatarUrl: string;
-  position: '보컬' | '댄서' | '랩';
-};
-
-const PAGE_SIZE = 6;
-
 export function useIdolSearch(debouncedSearchQuery: string) {
   const queryClient = useQueryClient();
   const { favorites, toggleFavorite } = useFavoritesStore();
@@ -43,12 +32,9 @@ export function useIdolSearch(debouncedSearchQuery: string) {
   } = useInfiniteQuery({
     queryKey: ['idols', 'search', debouncedSearchQuery],
     enabled: debouncedSearchQuery.trim().length > 0,
-    initialPageParam: 0,
-    queryFn: async ({ pageParam = 0 }) => {
-      await new Promise<void>(resolve => {
-        setTimeout(resolve, 300);
-      });
-      return searchIdols(debouncedSearchQuery, pageParam, PAGE_SIZE);
+    initialPageParam: 1, // DRF page=1부터 시작
+    queryFn: async ({ pageParam = 1 }) => {
+      return searchIdolsApi(debouncedSearchQuery, pageParam);
     },
     getNextPageParam: lastPage => lastPage.nextPage ?? undefined,
   });


### PR DESCRIPTION
## 🚀 PR 요약

> 아이돌 검색 페이지에 백엔드 API 연동 (검색어 기반 아이돌 목록 불러오기 + 페이지네이션 처리)

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.  
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.  
- [x] 이슈 브랜치 -> develop PR은 **squash and merge**, develop -> main PR은 **rebase and merge**를 선택했습니다.  

## 🗒️ 기타 참고사항

- 현재는 그룹명/포지션은 API 응답에 없어 카드에는 노출되지 않습니다. 추후 백엔드에서 제공 시 대응 가능합니다.  
- 이미지 URL 미제공 시 DiceBear 아바타가 fallback으로 표시됩니다.  
- 스크린샷 / GIF 첨부 예정 (아이돌 검색 동작 확인용) 
https://github.com/user-attachments/assets/6407fad1-c12f-4b54-8918-4e8324dc2d58


## 🔗 연관된 이슈

closes #163