### PR TITLE
Feat: 아이돌 검색 페이지 찜한 아이돌 조회 API 연동

### DIFF
--- a/src/api/bookmarkApi.ts
+++ b/src/api/bookmarkApi.ts
@@ -1,9 +1,10 @@
+import { type AxiosResponse } from 'axios';
+
 import type {
   BookmarkGroup,
   BookmarkIdol,
   PaginatedResponse,
 } from '@/types/bookmark';
-import { type AxiosResponse } from 'axios';
 
 import axiosInstance from './axiosInstance';
 
@@ -15,6 +16,7 @@ export const getBookmarkGroups = async () => {
   let url: string | null = '/bookmarks/groups/';
 
   while (url) {
+    // eslint-disable-next-line no-await-in-loop
     const response: AxiosResponse = await axiosInstance.get<
       PaginatedResponse<BookmarkGroup>
     >(url!);
@@ -33,6 +35,7 @@ export const getBookmarkIdols = async () => {
   let url: string | null = '/bookmarks/idols/';
 
   while (url) {
+    // eslint-disable-next-line no-await-in-loop
     const response: AxiosResponse = await axiosInstance.get<
       PaginatedResponse<BookmarkIdol>
     >(url!);

--- a/src/api/idolApi.ts
+++ b/src/api/idolApi.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/api/axiosInstance';
-import { toAbsolute } from '@/utils/toAbsolute';
+import { avatarFromServerOrDicebear } from '@/utils/avatar';
 
 type DRFPage<T> = {
   count: number;
@@ -36,21 +36,13 @@ export async function searchIdolsApi(
 
   const { results, next } = res.data;
 
-  const items: Idol[] = results.map(it => {
-    const raw = typeof it.avatar_url === 'string' ? it.avatar_url.trim() : '';
-    const serverUrl = raw ? toAbsolute(raw) : undefined;
-    const fallback = `https://api.dicebear.com/8.x/fun-emoji/svg?seed=${encodeURIComponent(
-      it.name,
-    )}`;
-
-    return {
-      id: String(it.id),
-      name: it.name,
-      avatarUrl: serverUrl ?? fallback,
-      groupName: (it as any).group_name ?? '', // 아직 없어서 빈값
-      position: (it as any).position ?? '', // 나중에 서버가 주면 자동 반영
-    };
-  });
+  const items: Idol[] = results.map(it => ({
+    id: String(it.id),
+    name: it.name,
+    avatarUrl: avatarFromServerOrDicebear(it.avatar_url, it.name),
+    groupName: (it as any).group_name ?? '', // 아직 없으면 빈값
+    position: (it as any).position ?? '', // 나중에 서버가 주면 자동 반영
+  }));
 
   return {
     items,

--- a/src/components/mypage/FavoriteIdols.tsx
+++ b/src/components/mypage/FavoriteIdols.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 
 import { useDraggable } from '@/hooks/useDraggable';
 import { useFavoritesStore } from '@/stores/favoritesStore';
+
 import FavoriteSection from './FavoriteSection';
 
 export default function FavoriteIdols() {

--- a/src/components/mypage/FavoriteSection.tsx
+++ b/src/components/mypage/FavoriteSection.tsx
@@ -1,7 +1,7 @@
+import Card from '@/components/common/card';
 import { mediaQuery } from '@/constants/breakpoints';
 import type { useDraggable } from '@/hooks/useDraggable';
 import useMediaQuery from '@/hooks/useMediaQuery';
-import Card from '@/components/common/card';
 
 interface FavoriteSectionProps {
   title: string;

--- a/src/pages/idolSearch/useIdolSearch.ts
+++ b/src/pages/idolSearch/useIdolSearch.ts
@@ -6,11 +6,10 @@ import {
 } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
+import { getBookmarkIdols } from '@/api/bookmarkApi';
 import { searchIdolsApi } from '@/api/idolApi';
 import { useSyncArrayData } from '@/hooks/useSyncArrayData';
-import { getBookmarkIdols } from '@/api/bookmarkApi';
 import { useFavoritesStore } from '@/stores/favoritesStore';
-
 import { avatarOf } from '@/utils/avatar';
 
 export function useIdolSearch(debouncedSearchQuery: string) {
@@ -60,7 +59,7 @@ export function useIdolSearch(debouncedSearchQuery: string) {
     serverData: favoriteIdols?.map(i => i.id),
     clientData: favorites,
     applyFn: toggleFavorite,
-    onSync: (_added, _removed) => {
+    onSync: () => {
       // TODO: 토글 API 붙으면 여기서 add/remove 호출
       syncFavoritesWithServer({} as any);
     },

--- a/src/pages/idolSearch/useIdolSearch.ts
+++ b/src/pages/idolSearch/useIdolSearch.ts
@@ -8,10 +8,8 @@ import { useMemo } from 'react';
 
 import { searchIdolsApi } from '@/api/idolApi';
 import { useSyncArrayData } from '@/hooks/useSyncArrayData';
-import {
-  fetchFavoriteIdols,
-  toggleFavorite as mockToggleFavorite,
-} from '@/mocks/data/idols';
+import { toggleFavorite as mockToggleFavorite } from '@/mocks/data/idols';
+import { fetchBookmarkedIdols } from '@/api/bookmarkApi';
 import { useFavoritesStore } from '@/stores/favoritesStore';
 
 export function useIdolSearch(debouncedSearchQuery: string) {
@@ -20,7 +18,7 @@ export function useIdolSearch(debouncedSearchQuery: string) {
 
   const { data: favoriteIdols, isLoading: isFavoritesLoading } = useQuery({
     queryKey: ['idols', 'favorites'],
-    queryFn: fetchFavoriteIdols,
+    queryFn: fetchBookmarkedIdols,
   });
 
   const {
@@ -33,7 +31,7 @@ export function useIdolSearch(debouncedSearchQuery: string) {
   } = useInfiniteQuery({
     queryKey: ['idols', 'search', debouncedSearchQuery],
     enabled: debouncedSearchQuery.trim().length > 0,
-    initialPageParam: 1, // DRF page=1부터 시작
+    initialPageParam: 1,
     queryFn: async ({ pageParam = 1 }) => {
       return searchIdolsApi(debouncedSearchQuery, pageParam);
     },

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,15 @@
+import { toAbsolute } from '@/utils/toAbsolute';
+
+// Dicebear fallback
+export const avatarOf = (seed: string) =>
+  `https://api.dicebear.com/8.x/fun-emoji/svg?seed=${encodeURIComponent(seed)}`;
+
+// 서버 url 있으면 절대경로, 없으면 dicebear
+export const avatarFromServerOrDicebear = (
+  rawUrl: string | null | undefined,
+  seed: string,
+) => {
+  const trimmed = typeof rawUrl === 'string' ? rawUrl.trim() : '';
+  if (trimmed) return toAbsolute(trimmed);
+  return avatarOf(seed);
+};


### PR DESCRIPTION
## 🚀 PR 요약

아이돌 검색 페이지에서 찜한 아이돌 조회 API를 연동했습니다.  
북마크 API를 통해 서버에 등록된 찜 아이돌 목록을 불러와 화면에 표시되도록 수정했습니다.


## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가


## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다. (closes #168)
- [x] 실행에 문제가 없는지 테스트했습니다.
- [x] 이슈 브랜치 -> develop PR은 **squash and merge**, develop -> main PR은 **rebase and merge**를 선택했습니다.

## 📸 스크린샷 (선택)
>  <img width="1722" height="700" alt="스크린샷 2025-08-25 오후 4 57 40" src="https://github.com/user-attachments/assets/582d4f73-3ccd-472d-b68c-023be3d44370" />


## 🗒️ 기타 참고사항

- 현재 토글 API는 아직 미연동 상태로, 추후 add/remove API 연동 시 로직 교체가 필요합니다.  
- 북마크 아이돌 데이터는 서버에서 제공되는 idol id, idol_name을 기반으로 사용합니다.  

## 🔗 연관된 이슈

closes #168