### PR TITLE
Feat: 팬 메인페이지 아이돌 상세 조회 API 연동

### DIFF
--- a/src/api/idolApi.ts
+++ b/src/api/idolApi.ts
@@ -49,3 +49,17 @@ export async function searchIdolsApi(
     nextPage: next ? page + 1 : undefined,
   };
 }
+
+// 아이돌 상세 조회 페이지
+export async function fetchIdolDetail(id: number | string): Promise<Idol> {
+  const res = await axiosInstance.get(`/idols/${id}/`);
+  const it = res.data as any;
+
+  return {
+    id: String(it.id),
+    name: it.name,
+    avatarUrl: avatarFromServerOrDicebear(it.avatar_url, it.name),
+    groupName: it.group_name ?? '',
+    position: it.position ?? '',
+  };
+}

--- a/src/api/idolApi.ts
+++ b/src/api/idolApi.ts
@@ -1,6 +1,6 @@
 import axiosInstance from '@/api/axiosInstance';
+import type { DRFPage, Idol, IdolServer } from '@/types/idol';
 import { avatarFromServerOrDicebear } from '@/utils/avatar';
-import type { DRFPage, IdolServer, Idol } from '@/types/idol';
 
 export async function searchIdolsApi(
   q: string,

--- a/src/api/idolApi.ts
+++ b/src/api/idolApi.ts
@@ -1,6 +1,7 @@
 import axiosInstance from '@/api/axiosInstance';
 import type { DRFPage, Idol, IdolServer } from '@/types/idol';
 import { avatarFromServerOrDicebear } from '@/utils/avatar';
+export type { Idol } from '@/types/idol';
 
 export async function searchIdolsApi(
   q: string,

--- a/src/api/idolApi.ts
+++ b/src/api/idolApi.ts
@@ -1,30 +1,6 @@
 import axiosInstance from '@/api/axiosInstance';
 import { avatarFromServerOrDicebear } from '@/utils/avatar';
-
-type DRFPage<T> = {
-  count: number;
-  next: string | null;
-  previous: string | null;
-  results: T[];
-};
-
-type IdolServer = {
-  id: number;
-  name: string;
-  user: number;
-  group: number | null;
-  created_at: string;
-  updated_at: string;
-  avatar_url?: string | null;
-};
-
-export type Idol = {
-  id: string;
-  name: string;
-  groupName?: string;
-  avatarUrl?: string;
-  position?: '보컬' | '댄서' | '랩';
-};
+import type { DRFPage, IdolServer, Idol } from '@/types/idol';
 
 export async function searchIdolsApi(
   q: string,
@@ -40,8 +16,8 @@ export async function searchIdolsApi(
     id: String(it.id),
     name: it.name,
     avatarUrl: avatarFromServerOrDicebear(it.avatar_url, it.name),
-    groupName: (it as any).group_name ?? '', // 아직 없으면 빈값
-    position: (it as any).position ?? '', // 나중에 서버가 주면 자동 반영
+    groupName: (it as any).group_name ?? '',
+    position: (it as any).position ?? '',
   }));
 
   return {
@@ -62,4 +38,10 @@ export async function fetchIdolDetail(id: number | string): Promise<Idol> {
     groupName: it.group_name ?? '',
     position: it.position ?? '',
   };
+}
+
+// 아이돌 전체 스케줄 조회
+export async function fetchIdolSchedules(id: number | string) {
+  const res = await axiosInstance.get(`/idols/${id}/schedules/`);
+  return res.data;
 }

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -111,7 +111,7 @@ export const ALL_SCHEDULES = [
     endTime: '2025-08-28T16:00:00',
     description: 'KBS 뮤직뱅크 사전 리허설 및 인터뷰',
     isPublic: true,
-    idol: { id: 2, name: '카리나' },
+    idol: { id: 1, name: '카리나' },
   },
   {
     id: 13,
@@ -120,7 +120,7 @@ export const ALL_SCHEDULES = [
     endTime: '2025-08-28T17:30:00',
     description: 'KBS 뮤직뱅크 본방송 출연',
     isPublic: true,
-    idol: { id: 2, name: '카리나' },
+    idol: { id: 1, name: '카리나' },
   },
   {
     id: 14,
@@ -129,7 +129,7 @@ export const ALL_SCHEDULES = [
     endTime: '2025-08-28T21:00:00',
     description: 'VOGUE 코리아 9월호 단독 화보 촬영',
     isPublic: true,
-    idol: { id: 2, name: '카리나' },
+    idol: { id: 1, name: '카리나' },
   },
   {
     id: 15,
@@ -138,7 +138,7 @@ export const ALL_SCHEDULES = [
     endTime: '2025-08-28T22:00:00',
     description: '카리나 솔로 앨범 발매 기념 팬사인회',
     isPublic: true,
-    idol: { id: 2, name: '카리나' },
+    idol: { id: 1, name: '카리나' },
   },
 
   // 🎵 에스파 그룹 활동도 추가 (카리나가 멤버로 참여)
@@ -151,7 +151,7 @@ export const ALL_SCHEDULES = [
     isPublic: true,
     group: { id: 200, name: '에스파' },
     members: [
-      { id: 2, name: '카리나' },
+      { id: 1, name: '카리나' },
       { id: 21, name: '윈터' },
       { id: 22, name: '지젤' },
       { id: 23, name: '닝닝' },

--- a/src/pages/main/fan/hooks/useFanMainData.ts
+++ b/src/pages/main/fan/hooks/useFanMainData.ts
@@ -1,15 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
 import dayjs, { Dayjs } from 'dayjs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { useQuery } from '@tanstack/react-query';
 import { fetchIdolDetail, fetchIdolSchedules } from '@/api/idolApi';
-
 import { useBookmarkSync } from '@/hooks/useBookmarkSync';
-
 // ⚠️ TODO(삭제 예정): 스케줄 API가 안정되면 아래 목업 import는 제거
 import { ALL_SCHEDULES } from '@/mocks/data';
-
 import type { Schedule } from '@/types/schedule';
 import { isGroupSchedule, isIdolSchedule } from '@/types/schedule';
 

--- a/src/pages/main/fan/hooks/useFanMainData.ts
+++ b/src/pages/main/fan/hooks/useFanMainData.ts
@@ -3,9 +3,11 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useQuery } from '@tanstack/react-query';
-import { fetchIdolDetail } from '@/api/idolApi';
+import { fetchIdolDetail, fetchIdolSchedules } from '@/api/idolApi';
 
 import { useBookmarkSync } from '@/hooks/useBookmarkSync';
+
+// ⚠️ TODO(삭제 예정): 스케줄 API가 안정되면 아래 목업 import는 제거
 import { ALL_SCHEDULES } from '@/mocks/data';
 
 import type { Schedule } from '@/types/schedule';
@@ -24,6 +26,12 @@ export function useFanMainData() {
     queryKey: ['idol', 'detail', parsedIdolId],
     enabled: Number.isFinite(parsedIdolId) && parsedIdolId > 0,
     queryFn: () => fetchIdolDetail(parsedIdolId),
+  });
+
+  const { data: idolSchedulesFromApi } = useQuery({
+    queryKey: ['idol', 'schedules', parsedIdolId],
+    enabled: Number.isFinite(parsedIdolId) && parsedIdolId > 0,
+    queryFn: () => fetchIdolSchedules(parsedIdolId),
   });
 
   const currentIdol = useMemo(
@@ -52,11 +60,30 @@ export function useFanMainData() {
       return;
     }
 
-    // ⚠️ 스케줄은 아직 목업(ALL_SCHEDULES) 필터 유지
-    //    → 추후 /api/v1/idols/{id}/schedules/ 로 교체 예정
+    const mappedFromApi: Schedule[] = (idolSchedulesFromApi ?? []).map(
+      (it: any) => ({
+        id: it.id ?? Math.random(),
+        title: it.title ?? '',
+        startTime: it.start_time ?? it.startTime ?? '',
+        endTime: it.end_time ?? it.endTime ?? '',
+        description: it.description ?? '',
+        isPublic: Boolean(it.is_public ?? it.isPublic ?? true),
+        idol: { id: currentIdol.id, name: currentIdol.name },
+        group: undefined,
+        members: undefined,
+        location: it.location ?? '',
+      }),
+    ) as Schedule[];
+
+    if (mappedFromApi.length > 0) {
+      setFilteredSchedules(mappedFromApi);
+      return;
+    }
+
+    // ⚠️ 서버 데이터가 아직 없으면 → 기존 목업 로직으로 fallback
     const { name: idolName, groupName } = currentIdol;
 
-    const schedules = ALL_SCHEDULES.filter(schedule => {
+    const schedulesFromMock = ALL_SCHEDULES.filter(schedule => {
       if (isIdolSchedule(schedule) && schedule.idol.name === idolName)
         return true;
       if (isGroupSchedule(schedule) && schedule.group.name === groupName)
@@ -67,8 +94,8 @@ export function useFanMainData() {
       return false;
     });
 
-    setFilteredSchedules(schedules);
-  }, [currentIdol]);
+    setFilteredSchedules(schedulesFromMock);
+  }, [currentIdol, idolSchedulesFromApi]);
 
   const handleFavoriteToggle = useCallback(() => {
     if (parsedIdolId) toggleFavorite(parsedIdolId);

--- a/src/pages/main/fan/hooks/useFanMainData.ts
+++ b/src/pages/main/fan/hooks/useFanMainData.ts
@@ -69,8 +69,6 @@ export function useFanMainData() {
         description: it.description ?? '',
         isPublic: Boolean(it.is_public ?? it.isPublic ?? true),
         idol: { id: currentIdol.id, name: currentIdol.name },
-        group: undefined,
-        members: undefined,
         location: it.location ?? '',
       }),
     ) as Schedule[];

--- a/src/pages/main/fan/hooks/useFanMainData.ts
+++ b/src/pages/main/fan/hooks/useFanMainData.ts
@@ -2,9 +2,12 @@ import dayjs, { Dayjs } from 'dayjs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { useQuery } from '@tanstack/react-query';
+import { fetchIdolDetail } from '@/api/idolApi';
+
 import { useBookmarkSync } from '@/hooks/useBookmarkSync';
 import { ALL_SCHEDULES } from '@/mocks/data';
-import { MOCK_IDOLS } from '@/mocks/data/idols';
+
 import type { Schedule } from '@/types/schedule';
 import { isGroupSchedule, isIdolSchedule } from '@/types/schedule';
 
@@ -17,9 +20,22 @@ export function useFanMainData() {
 
   const { favoriteIdols, toggleFavorite } = useBookmarkSync();
 
+  const { data: idolDetail } = useQuery({
+    queryKey: ['idol', 'detail', parsedIdolId],
+    enabled: Number.isFinite(parsedIdolId) && parsedIdolId > 0,
+    queryFn: () => fetchIdolDetail(parsedIdolId),
+  });
+
   const currentIdol = useMemo(
-    () => MOCK_IDOLS.find(idol => idol.id === parsedIdolId) ?? null,
-    [parsedIdolId],
+    () =>
+      idolDetail
+        ? {
+            id: Number(idolDetail.id),
+            name: idolDetail.name,
+            groupName: idolDetail.groupName ?? '',
+          }
+        : null,
+    [idolDetail],
   );
 
   const isFavorite = useMemo(
@@ -36,6 +52,8 @@ export function useFanMainData() {
       return;
     }
 
+    // ⚠️ 스케줄은 아직 목업(ALL_SCHEDULES) 필터 유지
+    //    → 추후 /api/v1/idols/{id}/schedules/ 로 교체 예정
     const { name: idolName, groupName } = currentIdol;
 
     const schedules = ALL_SCHEDULES.filter(schedule => {

--- a/src/types/idol.ts
+++ b/src/types/idol.ts
@@ -1,0 +1,24 @@
+export type DRFPage<T> = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+};
+
+export type IdolServer = {
+  id: number;
+  name: string;
+  user: number;
+  group: number | null;
+  created_at: string;
+  updated_at: string;
+  avatar_url?: string | null;
+};
+
+export type Idol = {
+  id: string;
+  name: string;
+  groupName?: string;
+  avatarUrl?: string;
+  position?: '보컬' | '댄서' | '랩';
+};


### PR DESCRIPTION
## 🚀 PR 요약
검색 페이지 → 아이돌 카드 클릭 시, 해당 아이돌 상세 및 스케줄을 API에 연동했습니다.  
(혹시몰라서 서버 데이터가 없을 경우에 한해 기존 목업 데이터로 폴백을 남겨두었습니다.)

## ✏️ 변경 유형
- [x] feat: 새로운 기능 추가

## ✅ 체크리스트
- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다. (예: #182)
- [x] 실행에 문제가 없는지 테스트했습니다.
- [x] 이슈 브랜치 -> develop PR은 **squash and merge**, develop -> main PR은 **rebase and merge**를 선택했습니다.

## 🖼️ 스크린샷/동영상 (선택)
> ![Vite + React + TS (2) mp4](https://github.com/user-attachments/assets/d90fb504-a5ca-4fac-9910-e474537b2c6f)


## 🗒️ 기타 참고사항
- 아이돌 상세: `GET /api/v1/idols/{id}/`
- 아이돌 스케줄: `GET /api/v1/idols/{id}/schedules/`
- 일단..현재 서버 스케줄이 비어 있는 경우, 화면 공백을 피하기 위해 `ALL_SCHEDULES`로 폴백합니다.  
  → 서버 데이터가 채워지면 자동으로 실데이터가 우선 적용됩니다.  


## 🔗 연관된 이슈
closes #182
