### PR TITLE
Refactor: 채팅 페이지 웹 소켓 연결

### DIFF
--- a/src/api/chatApi.ts
+++ b/src/api/chatApi.ts
@@ -7,9 +7,13 @@ export const getMyChatRoomListAPI = async () => {
   return res.data;
 };
 
-export const createNewChatRoomAPI = async (groupName: string) => {
+export const createNewChatRoomAPI = async (
+  id: number,
+  participantIds: number[],
+) => {
   const res = await axiosInstance.post(`${API_BASE_URL}/chats/rooms/`, {
-    room_name: `${groupName}Room`,
+    room_name: `ChatRoomBy${id}`,
+    participant_ids: participantIds,
   });
   return res.data;
 };
@@ -86,5 +90,10 @@ export const getChatRoomParticipantsAPI = async (
   const res = await axiosInstance.get(
     `${API_BASE_URL}/chats/rooms/${roomId}/participants/?page=${page}`,
   );
+  return res.data;
+};
+
+export const getGroupMembersAPI = async () => {
+  const res = await axiosInstance.get(`${API_BASE_URL}/groups/members/`);
   return res.data;
 };

--- a/src/api/chatApi.ts
+++ b/src/api/chatApi.ts
@@ -72,16 +72,19 @@ export const leaveChatRoomAPI = async (roomId: number, roomName: string) => {
   return res.data;
 };
 
-export const getChatMessageAPI = async (roomId: number) => {
+export const getChatMessageAPI = async (roomId: number, page: number) => {
   const res = await axiosInstance.get(
-    `${API_BASE_URL}/chats/rooms/${roomId}/messages/`,
+    `${API_BASE_URL}/chats/rooms/${roomId}/messages/?page=${page}`,
   );
   return res.data;
 };
 
-export const getChatRoomParticipantsAPI = async (roomId: number) => {
+export const getChatRoomParticipantsAPI = async (
+  roomId: number,
+  page: number,
+) => {
   const res = await axiosInstance.get(
-    `${API_BASE_URL}/chats/rooms/${roomId}/participants/`,
+    `${API_BASE_URL}/chats/rooms/${roomId}/participants/?page=${page}`,
   );
   return res.data;
 };

--- a/src/components/common/UserAvatarImage.tsx
+++ b/src/components/common/UserAvatarImage.tsx
@@ -22,7 +22,7 @@ const avatarSizeVariants = cva(
 );
 
 type UserAvatarImageProps = {
-  profileImageUrl?: string;
+  profileImageUrl?: string | null;
   altText?: string;
   avatarSize?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
   className?: string;

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -2,7 +2,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 
-import { createNewChatRoomAPI, getMyChatRoomListAPI } from '@/api/chatApi';
+import {
+  createNewChatRoomAPI,
+  getGroupMembersAPI,
+  getMyChatRoomListAPI,
+} from '@/api/chatApi';
 import { useChatStore } from '@/stores/chatRoomIdStore';
 import { useUserStore } from '@/stores/userStore';
 import { showErrorToast, showSuccessToast } from '@/utils/toastUtils';
@@ -11,13 +15,19 @@ import ChatComposer from './sections/chatComposer/ChatComposer';
 import ChatContactList from './sections/chatContactList/ChatContactList';
 import ChatMessageList from './sections/chatMessageList/ChatMessageList';
 
-const GROUP_NAME_TEST = 'test';
+interface MemberTypes {
+  id: number;
+  nickname: string;
+  role: 'IDOL' | 'MANAGER';
+  profile_image_url: string | null;
+}
 
 function Chat() {
   const [isVisible, setIsVisible] = useState(false);
   const [socket, setSocket] = useState<WebSocket | null>(null);
   const { roomId, setRoomId } = useChatStore();
-  const { accessToken } = useUserStore();
+  const { user, accessToken } = useUserStore();
+  const userId = user?.user_id;
   const queryClient = useQueryClient();
 
   const handleToggleConversationList = () => {
@@ -29,8 +39,16 @@ function Chat() {
     queryFn: getMyChatRoomListAPI,
   });
 
+  const groupMembersQuery = useQuery({
+    queryKey: ['getGroupMembers'],
+    queryFn: getGroupMembersAPI,
+  });
+
   const { mutate: createRoom } = useMutation({
-    mutationFn: () => createNewChatRoomAPI(GROUP_NAME_TEST),
+    mutationFn: (memberIds: number[]) => {
+      const currentUserId = userId || memberIds[0];
+      return createNewChatRoomAPI(currentUserId, memberIds);
+    },
     onSuccess: newRoom => {
       showSuccessToast('채팅방 생성 성공');
       setRoomId(newRoom.id);
@@ -51,14 +69,22 @@ function Chat() {
       return;
     }
 
-    if (roomList.count === 0) {
-      createRoom();
+    if (roomList.count === 0 && groupMembersQuery.data) {
+      const memberIds = groupMembersQuery.data.map(
+        (member: MemberTypes) => member.id,
+      );
+      createRoom(memberIds);
     } else {
       const currentRoomId = roomList.results[0].id;
       setRoomId(currentRoomId);
-      showSuccessToast(`채팅방 목록을 불러왔습니다!`);
     }
-  }, [createRoom, roomListQuery.data, roomListQuery.isError, setRoomId]);
+  }, [
+    createRoom,
+    groupMembersQuery.data,
+    roomListQuery.data,
+    roomListQuery.isError,
+    setRoomId,
+  ]);
 
   useEffect(() => {
     if (!roomId) return;
@@ -80,6 +106,9 @@ function Chat() {
     };
 
     setSocket(ws);
+
+    // eslint-disable-next-line consistent-return
+    return () => ws.close();
   }, [accessToken, roomId]);
 
   return (

--- a/src/pages/chat/chat.types.ts
+++ b/src/pages/chat/chat.types.ts
@@ -45,7 +45,8 @@ export type ChatMessage = {
   sender: {
     id: number;
     nickname: string;
-    profile_image: number;
+    role: 'NORMAL' | 'IDOL' | 'MANAGER';
+    profile_image_url: string;
   };
   content: string;
   sent_at: string;

--- a/src/pages/chat/chat.types.ts
+++ b/src/pages/chat/chat.types.ts
@@ -46,7 +46,7 @@ export type ChatMessage = {
     id: number;
     nickname: string;
     role: 'NORMAL' | 'IDOL' | 'MANAGER';
-    profile_image_url: string;
+    profile_image_url: string | null;
   };
   content: string;
   sent_at: string;

--- a/src/pages/chat/sections/chatComposer/ChatComposer.tsx
+++ b/src/pages/chat/sections/chatComposer/ChatComposer.tsx
@@ -5,10 +5,11 @@ import { useState } from 'react';
 import { ChatComposerButtonStyles } from '../../chat.styles';
 
 interface ChatComposerProps {
+  socket: WebSocket | null;
   onToggleList: () => void;
 }
 
-function ChatComposer({ onToggleList }: ChatComposerProps) {
+function ChatComposer({ socket, onToggleList }: ChatComposerProps) {
   const [inputValue, setInputValue] = useState('');
   const trimmedInputValue = inputValue.trim();
 
@@ -17,10 +18,10 @@ function ChatComposer({ onToggleList }: ChatComposerProps) {
   };
 
   const handleSendMessage = () => {
-    if (!trimmedInputValue) return;
-
-    // console.log(inputValue);
-    setInputValue('');
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ message: inputValue }));
+      setInputValue('');
+    }
   };
 
   const handleEnterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/pages/chat/sections/chatContactList/ChatContactGroup.tsx
+++ b/src/pages/chat/sections/chatContactList/ChatContactGroup.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 
@@ -6,7 +6,7 @@ import { getChatRoomParticipantsAPI } from '@/api/chatApi';
 import { useChatStore } from '@/stores/chatRoomIdStore';
 import { showErrorToast } from '@/utils/toastUtils';
 
-import type { ChatParticipant } from '../../chat.types';
+import type { ChatParticipant, PaginatedResponse } from '../../chat.types';
 import ChatContactItem from './ChatContactItem';
 
 interface ChatContactGroupProps {
@@ -16,10 +16,23 @@ interface ChatContactGroupProps {
 function ChatContactGroup({ isVisible }: ChatContactGroupProps) {
   const { roomId } = useChatStore();
 
-  const participantsQuery = useQuery<ChatParticipant[]>({
+  const participantsQuery = useInfiniteQuery<
+    PaginatedResponse<ChatParticipant>,
+    Error,
+    ChatParticipant[]
+  >({
     queryKey: ['getChatRoomParticipants', roomId],
-    queryFn: () => getChatRoomParticipantsAPI(roomId!),
+    queryFn: ({ pageParam }) =>
+      getChatRoomParticipantsAPI(roomId!, Number(pageParam)),
     enabled: !!roomId,
+    initialPageParam: 1,
+    getNextPageParam: lastPage => {
+      if (!lastPage.next) return undefined;
+      const url = new URL(lastPage.next);
+      const pageStr = url.searchParams.get('page');
+      return pageStr || undefined;
+    },
+    select: data => data.pages.flatMap(page => page.results),
   });
 
   useEffect(() => {

--- a/src/pages/chat/sections/chatContactList/ChatContactItem.tsx
+++ b/src/pages/chat/sections/chatContactList/ChatContactItem.tsx
@@ -1,4 +1,7 @@
+import clsx from 'clsx';
+
 import { UserAvatarImage } from '@/components/common/UserAvatarImage';
+import { useUserStore } from '@/stores/userStore';
 
 import type { ChatParticipant } from '../../chat.types';
 
@@ -7,10 +10,19 @@ interface ChatContactItemTypes {
 }
 
 function ChatContactItem({ contactData }: ChatContactItemTypes) {
-  const { nickname } = contactData;
+  const { user } = useUserStore();
+  const userId = user?.user_id;
+  const { id, nickname } = contactData;
+
+  const isMyId = id === userId;
 
   return (
-    <div className="flex cursor-pointer items-center gap-3 rounded-2xl bg-fuchsia-200 px-3 py-2 hover:bg-fuchsia-300">
+    <div
+      className={clsx(
+        'flex items-center gap-3 rounded-2xl px-3 py-2',
+        isMyId ? 'bg-fuchsia-400' : 'bg-fuchsia-200',
+      )}
+    >
       <UserAvatarImage />
       <span>{nickname}</span>
     </div>

--- a/src/pages/chat/sections/chatMessageList/ChatMessageGroup.tsx
+++ b/src/pages/chat/sections/chatMessageList/ChatMessageGroup.tsx
@@ -1,15 +1,14 @@
-// import { useUserStore } from '@/stores/userStore';
+import { useUserStore } from '@/stores/userStore';
+
 import type { ChatMessageGroupTypes } from '../../chat.types';
 import ChatMessageItem from './ChatMessageItem';
 import TimeDivider from './TimeDivider';
 
-const USER_ID = 0;
-
 function ChatMessageGroup({ tKey, tValue }: ChatMessageGroupTypes) {
-  // const { user } = useUserStore();
-  // const userId = user?.user_id;
+  const { user } = useUserStore();
+  const userId = user?.user_id;
 
-  const isLastMsgMine = tValue.at(-1)?.sender.id === USER_ID;
+  const isLastMsgMine = tValue.at(-1)?.sender.id === userId;
 
   return (
     <>

--- a/src/pages/chat/sections/chatMessageList/ChatMessageItem.tsx
+++ b/src/pages/chat/sections/chatMessageList/ChatMessageItem.tsx
@@ -1,20 +1,18 @@
 import clsx from 'clsx';
 
-// import { useUserStore } from '@/stores/userStore';
 import { UserAvatarImage } from '@/components/common/UserAvatarImage';
+import { useUserStore } from '@/stores/userStore';
 
 import { ChatMessageItemStyles } from '../../chat.styles';
 import type { GroupedChatTypes } from '../../chat.types';
 import ChatMessageBubble from './ChatMessageBubble';
 
-const USER_ID = 0;
-
 function ChatMessageItem(data: GroupedChatTypes) {
-  // const { user } = useUserStore();
-  // const userId = user?.user_id;
+  const { user } = useUserStore();
+  const userId = user?.user_id;
 
   const { sender, contents } = data;
-  const isMyChat = sender.id === USER_ID;
+  const isMyChat = sender.id === userId;
   const bubbles = contents.map(content => (
     <ChatMessageBubble
       key={content.id}
@@ -29,9 +27,7 @@ function ChatMessageItem(data: GroupedChatTypes) {
 
       {!isMyChat && (
         <>
-          <UserAvatarImage
-          // profileImageUrl={sender.profile_image}
-          />
+          <UserAvatarImage profileImageUrl={sender.profile_image_url} />
           <div className="flex w-full flex-col">
             <span className="text-xs font-medium text-gray-900">
               {sender.nickname}

--- a/src/pages/chat/sections/chatMessageList/ChatMessageList.tsx
+++ b/src/pages/chat/sections/chatMessageList/ChatMessageList.tsx
@@ -9,7 +9,6 @@ import {
   toGroupedChatMap,
   toSortedChats,
 } from '@/utils/chat.utils';
-import { showErrorToast } from '@/utils/toastUtils';
 
 import type {
   ChatMessage,
@@ -31,13 +30,14 @@ interface ChatMessageListProps {
 
 function ChatMessageList({ socket }: ChatMessageListProps) {
   const [atBottom, setAtBottom] = useState(true);
+  const [isFirstLoad, setIsFirstLoad] = useState(true);
+  const [rawMessages, setRawMessages] = useState<ChatMessage[]>([]);
   const { roomId } = useChatStore();
-  const [liveMessages, setLiveMessages] = useState<ChatMessage[]>([]);
 
   const messagesQuery = useInfiniteQuery<
     PaginatedResponse<ChatMessage>,
     Error,
-    ChatMessage[]
+    any
   >({
     queryKey: ['getChatMessage', roomId],
     queryFn: ({ pageParam }) => getChatMessageAPI(roomId!, Number(pageParam)),
@@ -46,59 +46,68 @@ function ChatMessageList({ socket }: ChatMessageListProps) {
     getNextPageParam: lastPage => {
       if (!lastPage.next) return undefined;
       const url = new URL(lastPage.next);
-      const pageStr = url.searchParams.get('page');
-      return pageStr || undefined;
+      return Number(url.searchParams.get('page'));
     },
-    select: data => data.pages.flatMap(page => page.results),
   });
 
   useEffect(() => {
-    if (!socket) return undefined;
-
-    if (messagesQuery.isError) {
-      showErrorToast('채팅방 메시지 조회 에러 발생');
+    if (isFirstLoad && messagesQuery.isSuccess && messagesQuery.data) {
+      setIsFirstLoad(false);
+      setRawMessages(messagesQuery.data.pages[0].results);
     }
+  }, [isFirstLoad, messagesQuery.data, messagesQuery.isSuccess]);
 
-    setLiveMessages(messagesQuery.data ?? []);
+  useEffect(() => {
+    if (!socket || !messagesQuery.data) return undefined;
 
-    // const handleMessage = (event: MessageEvent) => {
-    //   const data = JSON.parse(event.data);
-    //   console.log('data: ', data);
-    //   const newMessage = data.chat_room.last_message;
+    const handleMessage = (event: MessageEvent) => {
+      const data = JSON.parse(event.data);
 
-    //   queryClient.setQueryData(['getChatMessage', roomId], (old: any) => {
-    //     if (!old) return [newMessage];
-    //     return [...old, newMessage];
-    //   });
-    // };
+      if (data.type === 'chat.message') {
+        const newMessage: ChatMessage = data.message;
+        setRawMessages(prev => [...prev, newMessage]);
+      }
+    };
 
-    // socket.addEventListener('message', handleMessage);
+    socket.addEventListener('message', handleMessage);
 
-    // return () => {
-    //   socket.removeEventListener('message', handleMessage);
-    // };
-  }, [messagesQuery.data, messagesQuery.isError, roomId, socket]);
+    return () => {
+      socket.removeEventListener('message', handleMessage);
+    };
+  }, [messagesQuery, socket]);
 
-  const sortedChatData = toSortedChats(liveMessages ?? []);
+  const handleFetchNextPage = async (): Promise<void> => {
+    const res = await messagesQuery.fetchNextPage();
+    const lastPage = res.data?.pages.at(-1);
+    if (!lastPage) return;
 
-  const groupedChatData = toGroupedChatMap(sortedChatData);
+    setRawMessages(prev => [...lastPage.results, ...prev]);
+  };
 
-  const flattenChatData = toFlattenChats(groupedChatData);
+  const sorted = toSortedChats(rawMessages);
+  const grouped = toGroupedChatMap(sorted);
+  const flattenedChatData = toFlattenChats(grouped);
 
   return (
     <div className="h-full">
       <Virtuoso
-        className="chat-scrollbar flex flex-col py-2 pe-2"
-        data={flattenChatData}
-        computeItemKey={(_, data) => `D-${data.key}`}
-        alignToBottom
-        initialTopMostItemIndex={{
-          index: flattenChatData.length - 1,
-          align: 'end',
-        }}
+        className="chat-scrollbar py-2 pe-2"
+        data={flattenedChatData}
+        initialTopMostItemIndex={flattenedChatData.length - 1}
+        firstItemIndex={10000 - flattenedChatData.length}
+        computeItemKey={(_, data) => data.key}
         followOutput={atBottom ? 'smooth' : false}
         atBottomStateChange={setAtBottom}
         itemContent={renderDataByTime}
+        atTopStateChange={atTop => {
+          if (
+            atTop &&
+            messagesQuery.hasNextPage &&
+            !messagesQuery.isFetchingNextPage
+          )
+            handleFetchNextPage();
+        }}
+        increaseViewportBy={{ top: 200, bottom: 0 }}
       />
     </div>
   );

--- a/src/pages/chat/sections/chatMessageList/ChatMessageList.tsx
+++ b/src/pages/chat/sections/chatMessageList/ChatMessageList.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
@@ -11,7 +11,11 @@ import {
 } from '@/utils/chat.utils';
 import { showErrorToast } from '@/utils/toastUtils';
 
-import type { FlattenChatTypes } from '../../chat.types';
+import type {
+  ChatMessage,
+  FlattenChatTypes,
+  PaginatedResponse,
+} from '../../chat.types';
 import ChatMessageGroup from './ChatMessageGroup';
 import DateDivider from './DateDivider';
 
@@ -28,12 +32,24 @@ interface ChatMessageListProps {
 function ChatMessageList({ socket }: ChatMessageListProps) {
   const [atBottom, setAtBottom] = useState(true);
   const { roomId } = useChatStore();
-  const queryClient = useQueryClient();
+  const [liveMessages, setLiveMessages] = useState<ChatMessage[]>([]);
 
-  const messagesQuery = useQuery({
+  const messagesQuery = useInfiniteQuery<
+    PaginatedResponse<ChatMessage>,
+    Error,
+    ChatMessage[]
+  >({
     queryKey: ['getChatMessage', roomId],
-    queryFn: () => getChatMessageAPI(roomId!),
+    queryFn: ({ pageParam }) => getChatMessageAPI(roomId!, Number(pageParam)),
     enabled: !!roomId,
+    initialPageParam: 1,
+    getNextPageParam: lastPage => {
+      if (!lastPage.next) return undefined;
+      const url = new URL(lastPage.next);
+      const pageStr = url.searchParams.get('page');
+      return pageStr || undefined;
+    },
+    select: data => data.pages.flatMap(page => page.results),
   });
 
   useEffect(() => {
@@ -43,25 +59,27 @@ function ChatMessageList({ socket }: ChatMessageListProps) {
       showErrorToast('채팅방 메시지 조회 에러 발생');
     }
 
-    const handleMessage = (event: MessageEvent) => {
-      const newMessage = JSON.parse(event.data);
+    setLiveMessages(messagesQuery.data ?? []);
 
-      console.log('서버에서 온 메시지', event.data);
+    // const handleMessage = (event: MessageEvent) => {
+    //   const data = JSON.parse(event.data);
+    //   console.log('data: ', data);
+    //   const newMessage = data.chat_room.last_message;
 
-      queryClient.setQueryData(['getChatMessage', roomId], (old: any) => {
-        if (!old) return [newMessage];
-        return [...old, newMessage];
-      });
-    };
+    //   queryClient.setQueryData(['getChatMessage', roomId], (old: any) => {
+    //     if (!old) return [newMessage];
+    //     return [...old, newMessage];
+    //   });
+    // };
 
-    socket.addEventListener('message', handleMessage);
+    // socket.addEventListener('message', handleMessage);
 
-    return () => {
-      socket.removeEventListener('message', handleMessage);
-    };
-  }, [messagesQuery.isError, queryClient, roomId, socket]);
+    // return () => {
+    //   socket.removeEventListener('message', handleMessage);
+    // };
+  }, [messagesQuery.data, messagesQuery.isError, roomId, socket]);
 
-  const sortedChatData = toSortedChats(messagesQuery.data ?? []);
+  const sortedChatData = toSortedChats(liveMessages ?? []);
 
   const groupedChatData = toGroupedChatMap(sortedChatData);
 

--- a/src/utils/chat.utils.ts
+++ b/src/utils/chat.utils.ts
@@ -57,12 +57,17 @@ export const toFlattenChats = (
   groupedChatMap: GroupedChatListTypes,
 ): FlattenChatTypes[] =>
   Object.entries(groupedChatMap).flatMap(([dKey, timeMap]) => {
+    const firstMessageId = Object.values(timeMap)[0]?.[0]?.id;
+
     const timeEntries = Object.entries(timeMap).map(([tKey, tValue]) => ({
       type: 'time' as const,
       dKey,
       tKey,
       tValue,
-      key: `T-${dKey}-${tKey}`,
+      key: `T-${dKey}-${tKey}-${tValue[0]?.id}`,
     }));
-    return [{ type: 'date' as const, dKey, key: `D-${dKey}` }, ...timeEntries];
+    return [
+      { type: 'date' as const, dKey, key: `D-${dKey}-${firstMessageId}` },
+      ...timeEntries,
+    ];
   });


### PR DESCRIPTION
## 🚀 PR 요약

채팅 페이지에 웹 소켓을 연결하고, 메시지 조회 데이터가 페이지네이션 되어 있어 무한 스크롤을 적용했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

### 채팅 페이지 Flow
1. 관리자가 특정 아이돌 그룹의 모든 아이돌 멤버와 매니저 계정을 추가한다.
2. 매니저가 아이돌 그룹 정보를 생성한다.
3. 관리자가 생성된 아이돌 그룹 데이터에 각 아이돌 정보를 patch로 연결한다.
4. 특정 그룹의 아이돌 또는 매니저가 사이트 이용 시작 후 처음으로 채팅 페이지에 입장한다.
5. 그룹 구성원(아이돌 및 매니저) id 값을 가져와 그들 모두를 참여자로 지정한 채팅방을 생성한다.
6. 이후 해당 그룹 내 아이돌과 매니저가 채팅 페이지 입장 시 이전에 생성된 채팅방으로 자동 입장하여 서로 채팅을 주고받을 수 있다.

### 추가 사항
- API 명세서를 참고하여 API 요청 값 및 반환 값 타입 수정
- 웹 소켓 연결
- 메시지 조회 데이터 렌더링 시 무한스크롤 적용

### 스크린샷

(아래 영상에서 채팅 페이지로 입장할 때 url에 직접 **/chat**을 입력했는데, **채팅 버튼**을 눌러 채팅 페이지로 이동할 수 있도록 수정할 예정입니다.)

https://github.com/user-attachments/assets/042ca780-44c3-4716-b68f-bdf2622cd7e6



## 🔗 연관된 이슈

> closes #159 
