### PR TITLE
Feat: 스케줄 찜 조회/추가/수정 api 연결 및 기능 구현

### DIFF
--- a/src/api/bookmarkApi.ts
+++ b/src/api/bookmarkApi.ts
@@ -3,6 +3,7 @@ import { type AxiosResponse } from 'axios';
 import type {
   BookmarkGroup,
   BookmarkIdol,
+  BookmarkSchedule,
   PaginatedResponse,
 } from '@/types/bookmark';
 
@@ -76,4 +77,23 @@ export const addBookmarkIdol = async (idolId: number) => {
  */
 export const removeBookmarkIdol = async (bookmarkId: number) => {
   await axiosInstance.delete(`/bookmarks/idols/${bookmarkId}/`);
+};
+
+/**
+ * 내가 북마크한 스케줄 목록 전체 조회
+ */
+export const getBookmarkSchedules = async () => {
+  let allSchedules: BookmarkSchedule[] = [];
+  let url: string | null = '/schedules/my/';
+
+  while (url) {
+    // eslint-disable-next-line no-await-in-loop
+    const response: AxiosResponse = await axiosInstance.get<
+      PaginatedResponse<BookmarkSchedule>
+    >(url!);
+    allSchedules = allSchedules.concat(response.data.results);
+    url = response.data.next;
+  }
+
+  return allSchedules;
 };

--- a/src/api/bookmarkIdolApi.ts
+++ b/src/api/bookmarkIdolApi.ts
@@ -3,7 +3,6 @@ import { type AxiosResponse } from 'axios';
 import type {
   BookmarkGroup,
   BookmarkIdol,
-  BookmarkSchedule,
   PaginatedResponse,
 } from '@/types/bookmark';
 
@@ -77,23 +76,4 @@ export const addBookmarkIdol = async (idolId: number) => {
  */
 export const removeBookmarkIdol = async (bookmarkId: number) => {
   await axiosInstance.delete(`/bookmarks/idols/${bookmarkId}/`);
-};
-
-/**
- * 내가 북마크한 스케줄 목록 전체 조회
- */
-export const getBookmarkSchedules = async () => {
-  let allSchedules: BookmarkSchedule[] = [];
-  let url: string | null = '/schedules/my/';
-
-  while (url) {
-    // eslint-disable-next-line no-await-in-loop
-    const response: AxiosResponse = await axiosInstance.get<
-      PaginatedResponse<BookmarkSchedule>
-    >(url!);
-    allSchedules = allSchedules.concat(response.data.results);
-    url = response.data.next;
-  }
-
-  return allSchedules;
 };

--- a/src/api/bookmarkScheduleApi.ts
+++ b/src/api/bookmarkScheduleApi.ts
@@ -1,8 +1,17 @@
 import { type AxiosResponse } from 'axios';
 
-import type { BookmarkSchedule, PaginatedResponse } from '@/types/bookmark';
+import type {
+  BookmarkSchedule,
+  BookmarkScheduleDetail,
+  PaginatedResponse,
+} from '@/types/bookmark';
 
 import axiosInstance from './axiosInstance';
+
+interface AddMyScheduleBody {
+  idol_schedule?: number;
+  group_schedule?: number;
+}
 
 /**
  * 내가 북마크한 스케줄 목록 전체 조회
@@ -21,4 +30,31 @@ export const getBookmarkSchedules = async () => {
   }
 
   return allSchedules;
+};
+
+/**
+ * 내 스케줄에 스케줄 북마크 추가
+ * @param body - idol_schedule 또는 group_schedule ID를 포함하는 객체
+ */
+export const addMySchedule = async (body: AddMyScheduleBody) => {
+  await axiosInstance.post('/schedules/my/', body);
+};
+
+/**
+ * 내 스케줄에서 스케줄 북마크 제거
+ * @param bookmarkId - 제거할 북마크의 ID
+ */
+export const removeMySchedule = async (bookmarkId: number) => {
+  await axiosInstance.delete(`/schedules/my/${bookmarkId}/`);
+};
+
+/**
+ * 내 스케줄 상세 조회
+ * @param bookmarkId - 조회할 북마크의 ID
+ */
+export const getMySchedule = async (bookmarkId: number) => {
+  const response = await axiosInstance.get<BookmarkScheduleDetail>(
+    `/schedules/my/${bookmarkId}/`,
+  );
+  return response.data;
 };

--- a/src/api/bookmarkScheduleApi.ts
+++ b/src/api/bookmarkScheduleApi.ts
@@ -1,0 +1,24 @@
+import { type AxiosResponse } from 'axios';
+
+import type { BookmarkSchedule, PaginatedResponse } from '@/types/bookmark';
+
+import axiosInstance from './axiosInstance';
+
+/**
+ * 내가 북마크한 스케줄 목록 전체 조회
+ */
+export const getBookmarkSchedules = async () => {
+  let allSchedules: BookmarkSchedule[] = [];
+  let url: string | null = '/schedules/my/';
+
+  while (url) {
+    // eslint-disable-next-line no-await-in-loop
+    const response: AxiosResponse = await axiosInstance.get<
+      PaginatedResponse<BookmarkSchedule>
+    >(url!);
+    allSchedules = allSchedules.concat(response.data.results);
+    url = response.data.next;
+  }
+
+  return allSchedules;
+};

--- a/src/api/idolApi.ts
+++ b/src/api/idolApi.ts
@@ -1,6 +1,7 @@
 import axiosInstance from '@/api/axiosInstance';
 import type { DRFPage, Idol, IdolServer } from '@/types/idol';
 import { avatarFromServerOrDicebear } from '@/utils/avatar';
+
 export type { Idol } from '@/types/idol';
 
 export async function searchIdolsApi(

--- a/src/components/common/dateSchedule/DateScheduleItem.tsx
+++ b/src/components/common/dateSchedule/DateScheduleItem.tsx
@@ -11,7 +11,6 @@ import {
 import clsx from 'clsx';
 import { useState } from 'react';
 
-import { useFavoriteSchedulesStore } from '@/stores/favoriteSchedulesStore';
 import { isGroupSchedule, isIdolSchedule } from '@/types/schedule';
 
 import type { DateScheduleItemProps } from './dateSchedule.types';
@@ -47,16 +46,13 @@ export default function DateScheduleItem({
   onNotifyToggle,
   onEditClick,
   onDeleteClick,
+  toggleScheduleBookmark,
 }: DateScheduleItemProps) {
   const [isOpen, setIsOpen] = useState(false);
   const handleToggleOpen = () => setIsOpen(prev => !prev);
 
-  const { toggleFavoriteSchedule, isFavoriteSchedule } =
-    useFavoriteSchedulesStore();
-
   const actionsInfo = getScheduleActions(userRole, item, {
-    toggleFavoriteSchedule,
-    isFavoriteSchedule,
+    toggleScheduleBookmark,
     onNotifyToggle,
     onEditClick,
     onDeleteClick,

--- a/src/components/common/dateSchedule/DateScheduleList.tsx
+++ b/src/components/common/dateSchedule/DateScheduleList.tsx
@@ -17,6 +17,7 @@ function DateScheduleList({
   onEditClick,
   onDeleteClick,
   className,
+  toggleScheduleBookmark,
 }: DateScheduleListProps) {
   const items = sortByTimeAsc(filterByDate(schedules, selectedDate));
 
@@ -44,7 +45,7 @@ function DateScheduleList({
         </p>
       ) : (
         <ul className="flex flex-col gap-2.5 md:gap-3">
-          {items.slice(0, 4).map(item => (
+          {items.map(item => (
             <DateScheduleItem
               key={item.id}
               item={item}
@@ -52,6 +53,7 @@ function DateScheduleList({
               onNotifyToggle={onNotifyToggle}
               onEditClick={onEditClick}
               onDeleteClick={onDeleteClick}
+              toggleScheduleBookmark={toggleScheduleBookmark}
             />
           ))}
         </ul>

--- a/src/components/common/dateSchedule/dateSchedule.types.ts
+++ b/src/components/common/dateSchedule/dateSchedule.types.ts
@@ -17,11 +17,13 @@ export interface DateScheduleListProps extends ScheduleActionProps {
   selectedDate: string;
   schedules: Schedule[];
   className?: string;
+  toggleScheduleBookmark?: (schedule: Schedule) => void;
 }
 
 export interface DateScheduleItemProps extends ScheduleActionProps {
   item: Schedule;
   userRole: UserRole;
+  toggleScheduleBookmark?: (schedule: Schedule) => void;
 }
 
 // 아이콘 버튼 컴포넌트 Props 타입

--- a/src/components/common/dateSchedule/getScheduleActions.ts
+++ b/src/components/common/dateSchedule/getScheduleActions.ts
@@ -40,7 +40,7 @@ export function getScheduleActions(
     onDeleteClick,
   }: Handlers,
 ): ScheduleActionInfo[] {
-  const isBookmarked = item.isBookmarked;
+  const { isBookmarked } = item;
 
   switch (userRole) {
     case 'fan':

--- a/src/components/common/dateSchedule/getScheduleActions.ts
+++ b/src/components/common/dateSchedule/getScheduleActions.ts
@@ -24,8 +24,7 @@ export interface ScheduleActionInfo {
 }
 
 type Handlers = {
-  toggleFavoriteSchedule: (schedule: Schedule) => void;
-  isFavoriteSchedule: (scheduleId: number) => boolean;
+  toggleScheduleBookmark: (schedule: Schedule) => void;
   onNotifyToggle?: (id: number) => void;
   onEditClick?: (id: number) => void;
   onDeleteClick?: (id: number) => void;
@@ -35,21 +34,22 @@ export function getScheduleActions(
   userRole: UserRole,
   item: Schedule,
   {
-    toggleFavoriteSchedule,
-    isFavoriteSchedule,
+    toggleScheduleBookmark,
     onNotifyToggle,
     onEditClick,
     onDeleteClick,
   }: Handlers,
 ): ScheduleActionInfo[] {
+  const isBookmarked = item.isBookmarked;
+
   switch (userRole) {
     case 'fan':
       return [
         {
           key: 'bookmark',
           ariaLabel: '즐겨찾기',
-          icon: isFavoriteSchedule(item.id) ? 'star-filled' : 'star',
-          onClick: () => toggleFavoriteSchedule(item),
+          icon: isBookmarked ? 'star-filled' : 'star',
+          onClick: () => toggleScheduleBookmark(item),
         },
       ];
 
@@ -58,8 +58,8 @@ export function getScheduleActions(
         {
           key: 'bookmark',
           ariaLabel: '즐겨찾기',
-          icon: isFavoriteSchedule(item.id) ? 'star-filled' : 'star',
-          onClick: () => toggleFavoriteSchedule(item),
+          icon: isBookmarked ? 'star-filled' : 'star',
+          onClick: () => toggleScheduleBookmark(item),
         },
         {
           key: 'notification',

--- a/src/components/common/dateSchedule/getScheduleActions.ts
+++ b/src/components/common/dateSchedule/getScheduleActions.ts
@@ -24,7 +24,7 @@ export interface ScheduleActionInfo {
 }
 
 type Handlers = {
-  toggleScheduleBookmark: (schedule: Schedule) => void;
+  toggleScheduleBookmark?: (schedule: Schedule) => void;
   onNotifyToggle?: (id: number) => void;
   onEditClick?: (id: number) => void;
   onDeleteClick?: (id: number) => void;
@@ -40,7 +40,7 @@ export function getScheduleActions(
     onDeleteClick,
   }: Handlers,
 ): ScheduleActionInfo[] {
-  const { isBookmarked } = item;
+  const isBookmarked = item.isBookmarked;
 
   switch (userRole) {
     case 'fan':
@@ -49,7 +49,7 @@ export function getScheduleActions(
           key: 'bookmark',
           ariaLabel: '즐겨찾기',
           icon: isBookmarked ? 'star-filled' : 'star',
-          onClick: () => toggleScheduleBookmark(item),
+          onClick: () => toggleScheduleBookmark?.(item),
         },
       ];
 
@@ -59,7 +59,7 @@ export function getScheduleActions(
           key: 'bookmark',
           ariaLabel: '즐겨찾기',
           icon: isBookmarked ? 'star-filled' : 'star',
-          onClick: () => toggleScheduleBookmark(item),
+          onClick: () => toggleScheduleBookmark?.(item),
         },
         {
           key: 'notification',

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -23,11 +23,20 @@ function Header() {
     }
   };
 
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      handleLogoClick();
+    }
+  };
+
   return (
     <header className="fixed top-0 right-0 left-0 z-50 h-16 border-b border-gray-300 bg-white px-6 md:px-10">
       <div className="mx-auto flex h-full max-w-screen-xl items-center justify-between">
         <div
           onClick={handleLogoClick}
+          onKeyDown={onKeyDown}
+          role="button"
+          tabIndex={0}
           className="cursor-pointer text-xl font-bold"
         >
           DingDing

--- a/src/hooks/useBookmarkSync.ts
+++ b/src/hooks/useBookmarkSync.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import {
   addBookmarkIdol,
@@ -59,23 +59,31 @@ export function useBookmarkSync() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['idols', 'favorites'] });
       queryClient.invalidateQueries({ queryKey: ['groups', 'favorites'] });
-      useFavoritesStore.getState().fetchFavorites();
     },
   });
+
+  const toggleFavoriteAndSync = useCallback(
+    (idolId: number) => {
+      const isCurrentlyFavorited = favorites.includes(idolId);
+      if (isCurrentlyFavorited) {
+        syncFavoritesWithServer({ added: [], removed: [idolId] });
+      } else {
+        syncFavoritesWithServer({ added: [idolId], removed: [] });
+      }
+    },
+    [favorites, syncFavoritesWithServer],
+  );
 
   useSyncArrayData<number>({
     serverData: bookmarkedIdolsRaw?.map(b => b.idol),
     clientData: favorites,
     applyFn: toggleFavorite,
-    onSync: (added, removed) => {
-      syncFavoritesWithServer({ added, removed });
-    },
   });
 
   return {
     favoriteIdols,
     favoriteGroups,
     isFavoritesLoading,
-    toggleFavorite,
+    toggleFavorite: toggleFavoriteAndSync,
   };
 }

--- a/src/hooks/useBookmarkSync.ts
+++ b/src/hooks/useBookmarkSync.ts
@@ -6,7 +6,7 @@ import {
   getBookmarkGroups,
   getBookmarkIdols,
   removeBookmarkIdol,
-} from '@/api/bookmarkApi';
+} from '@/api/bookmarkIdolApi';
 import { useSyncArrayData } from '@/hooks/useSyncArrayData';
 import { useFavoritesStore } from '@/stores/favoritesStore';
 

--- a/src/hooks/useMyScheduleData.ts
+++ b/src/hooks/useMyScheduleData.ts
@@ -1,16 +1,63 @@
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 
 import { getBookmarkSchedules } from '@/api/bookmarkScheduleApi';
-import type { BookmarkSchedule } from '@/types/bookmark';
+import type { BookmarkSchedule, RawScheduleContent } from '@/types/bookmark';
+import type {
+  Schedule,
+  IdolInfo,
+  GroupInfo,
+  IdolSchedule,
+  GroupSchedule,
+} from '@/types/schedule';
 
 export function useMyScheduleData() {
-  const { data, isLoading, isError, error } = useQuery<BookmarkSchedule[], Error>({
+  const { data, isLoading, isError, error } = useQuery<
+    BookmarkSchedule[],
+    Error
+  >({
     queryKey: ['mySchedules'],
     queryFn: getBookmarkSchedules,
   });
 
+  const mySchedules: Schedule[] = useMemo(() => {
+    return (data ?? []).map(bookmark => {
+      const scheduleContent: RawScheduleContent = bookmark.schedule_details; // Access schedule_details
+
+      const baseSchedule = {
+        id: bookmark.id,
+        title: scheduleContent.title,
+        startTime: scheduleContent.start_time,
+        endTime: scheduleContent.end_time,
+        location: scheduleContent.location,
+        description: scheduleContent.description,
+        isPublic: scheduleContent.is_public,
+      };
+
+      if (scheduleContent.idol) {
+        return {
+          ...baseSchedule,
+          idol: {
+            id: scheduleContent.idol,
+            name: scheduleContent.title,
+          } as IdolInfo,
+        } as IdolSchedule;
+      } else if (scheduleContent.group) {
+        return {
+          ...baseSchedule,
+          group: {
+            id: scheduleContent.group,
+            name: scheduleContent.title,
+          } as GroupInfo,
+        } as GroupSchedule;
+      } else {
+        return baseSchedule as Schedule;
+      }
+    });
+  }, [data]);
+
   return {
-    mySchedules: data ?? [],
+    mySchedules,
     isLoading,
     isError,
     error,

--- a/src/hooks/useMyScheduleData.ts
+++ b/src/hooks/useMyScheduleData.ts
@@ -4,11 +4,11 @@ import { useMemo } from 'react';
 import { getBookmarkSchedules } from '@/api/bookmarkScheduleApi';
 import type { BookmarkSchedule, RawScheduleContent } from '@/types/bookmark';
 import type {
-  Schedule,
-  IdolInfo,
   GroupInfo,
-  IdolSchedule,
   GroupSchedule,
+  IdolInfo,
+  IdolSchedule,
+  Schedule,
 } from '@/types/schedule';
 
 export function useMyScheduleData() {
@@ -43,7 +43,8 @@ export function useMyScheduleData() {
             name: scheduleContent.title,
           } as IdolInfo,
         } as IdolSchedule;
-      } else if (scheduleContent.group) {
+      }
+      if (scheduleContent.group) {
         return {
           ...baseSchedule,
           group: {
@@ -51,9 +52,8 @@ export function useMyScheduleData() {
             name: scheduleContent.title,
           } as GroupInfo,
         } as GroupSchedule;
-      } else {
-        return baseSchedule as Schedule;
       }
+      return baseSchedule as Schedule;
     });
   }, [data]);
 

--- a/src/hooks/useMyScheduleData.ts
+++ b/src/hooks/useMyScheduleData.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getBookmarkSchedules } from '@/api/bookmarkScheduleApi';
+import type { BookmarkSchedule } from '@/types/bookmark';
+
+export function useMyScheduleData() {
+  const { data, isLoading, isError, error } = useQuery<BookmarkSchedule[], Error>({
+    queryKey: ['mySchedules'],
+    queryFn: getBookmarkSchedules,
+  });
+
+  return {
+    mySchedules: data ?? [],
+    isLoading,
+    isError,
+    error,
+  };
+}

--- a/src/hooks/useMyScheduleData.ts
+++ b/src/hooks/useMyScheduleData.ts
@@ -32,6 +32,7 @@ export function useMyScheduleData() {
         location: scheduleContent.location,
         description: scheduleContent.description,
         isPublic: scheduleContent.is_public,
+        isBookmarked: true,
       };
 
       if (scheduleContent.idol) {

--- a/src/pages/MySchedule.tsx
+++ b/src/pages/MySchedule.tsx
@@ -1,15 +1,38 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import Calendar from '@/components/common/calendar/Calendar';
 import DateScheduleList from '@/components/common/dateSchedule/DateScheduleList';
+import { addMySchedule, removeMySchedule } from '@/api/bookmarkScheduleApi';
 import { useMyScheduleData } from '@/hooks/useMyScheduleData';
+import type { Schedule } from '@/types/schedule';
 
 export default function MySchedule() {
   const [selectedDate, setSelectedDate] = useState(dayjs());
   const [viewDate, setViewDate] = useState(dayjs());
 
   const { mySchedules, isLoading, isError } = useMyScheduleData();
+  const queryClient = useQueryClient();
+
+  const { mutate: toggleScheduleBookmark } = useMutation({
+    mutationFn: async (schedule: Schedule) => {
+      if (schedule.isBookmarked) {
+        await removeMySchedule(schedule.id);
+      } else {
+        if ('idol' in schedule && schedule.idol) {
+          await addMySchedule({ idol_schedule: schedule.idol.id });
+        } else if ('group' in schedule && schedule.group) {
+          await addMySchedule({ group_schedule: schedule.group.id });
+        } else {
+          throw new Error('Cannot bookmark schedule without idol or group ID');
+        }
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['mySchedules'] });
+    },
+  });
 
   const monthlySchedules = useMemo(() => {
     return mySchedules.filter(schedule =>
@@ -52,6 +75,7 @@ export default function MySchedule() {
         userRole="favorites"
         selectedDate={selectedDate.format('YYYY-MM-DD')}
         schedules={dailySchedules}
+        toggleScheduleBookmark={toggleScheduleBookmark}
       />
     </>
   );

--- a/src/pages/MySchedule.tsx
+++ b/src/pages/MySchedule.tsx
@@ -1,10 +1,10 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import dayjs, { Dayjs } from 'dayjs';
 import { useMemo, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { addMySchedule, removeMySchedule } from '@/api/bookmarkScheduleApi';
 import Calendar from '@/components/common/calendar/Calendar';
 import DateScheduleList from '@/components/common/dateSchedule/DateScheduleList';
-import { addMySchedule, removeMySchedule } from '@/api/bookmarkScheduleApi';
 import { useMyScheduleData } from '@/hooks/useMyScheduleData';
 import type { Schedule } from '@/types/schedule';
 
@@ -19,14 +19,12 @@ export default function MySchedule() {
     mutationFn: async (schedule: Schedule) => {
       if (schedule.isBookmarked) {
         await removeMySchedule(schedule.id);
+      } else if ('idol' in schedule && schedule.idol) {
+        await addMySchedule({ idol_schedule: schedule.idol.id });
+      } else if ('group' in schedule && schedule.group) {
+        await addMySchedule({ group_schedule: schedule.group.id });
       } else {
-        if ('idol' in schedule && schedule.idol) {
-          await addMySchedule({ idol_schedule: schedule.idol.id });
-        } else if ('group' in schedule && schedule.group) {
-          await addMySchedule({ group_schedule: schedule.group.id });
-        } else {
-          throw new Error('Cannot bookmark schedule without idol or group ID');
-        }
+        throw new Error('Cannot bookmark schedule without idol or group ID');
       }
     },
     onSuccess: () => {

--- a/src/pages/MySchedule.tsx
+++ b/src/pages/MySchedule.tsx
@@ -1,46 +1,27 @@
 import dayjs, { Dayjs } from 'dayjs';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import Calendar from '@/components/common/calendar/Calendar';
 import DateScheduleList from '@/components/common/dateSchedule/DateScheduleList';
-import type { Schedule } from '@/types/schedule';
+import { useMyScheduleData } from '@/hooks/useMyScheduleData';
 
 export default function MySchedule() {
   const [selectedDate, setSelectedDate] = useState(dayjs());
   const [viewDate, setViewDate] = useState(dayjs());
-  const [allSchedules, setAllSchedules] = useState<Schedule[]>([]);
 
-  useEffect(() => {
-    const fetchAllSchedules = async () => {
-      try {
-        const response = await fetch('/schedules/my');
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        const data: Schedule[] = await response.json();
-        setAllSchedules(data);
-      } catch (error) {
-        // console.error('Failed to fetch all schedules:', error);
-        setAllSchedules([]);
-      }
-    };
+  const { mySchedules, isLoading, isError } = useMyScheduleData();
 
-    fetchAllSchedules();
-  }, []);
-
-  // Calendar에 전달할 월별 스케줄
   const monthlySchedules = useMemo(() => {
-    return allSchedules.filter(schedule =>
+    return mySchedules.filter(schedule =>
       dayjs(schedule.startTime).isSame(viewDate, 'month'),
     );
-  }, [allSchedules, viewDate]);
+  }, [mySchedules, viewDate]);
 
-  // DateScheduleList에 전달할 일별 스케줄
   const dailySchedules = useMemo(() => {
-    return allSchedules.filter(schedule =>
+    return mySchedules.filter(schedule =>
       dayjs(schedule.startTime).isSame(selectedDate, 'day'),
     );
-  }, [allSchedules, selectedDate]);
+  }, [mySchedules, selectedDate]);
 
   const handleCalendarDateChange = (date: Dayjs) => {
     setSelectedDate(date);
@@ -48,6 +29,14 @@ export default function MySchedule() {
       setViewDate(date);
     }
   };
+
+  if (isLoading) {
+    return <div>내 스케줄을 불러오는 중...</div>;
+  }
+
+  if (isError) {
+    return <div>내 스케줄을 불러오는데 실패했습니다.</div>;
+  }
 
   return (
     <>

--- a/src/pages/idolSearch/useIdolSearch.ts
+++ b/src/pages/idolSearch/useIdolSearch.ts
@@ -10,7 +10,7 @@ import {
   addBookmarkIdol,
   getBookmarkIdols,
   removeBookmarkIdol,
-} from '@/api/bookmarkApi';
+} from '@/api/bookmarkIdolApi';
 import { searchIdolsApi } from '@/api/idolApi';
 import { useSyncArrayData } from '@/hooks/useSyncArrayData';
 import { useFavoritesStore } from '@/stores/favoritesStore';

--- a/src/pages/main/fan/FanMainPage.tsx
+++ b/src/pages/main/fan/FanMainPage.tsx
@@ -18,6 +18,7 @@ export default function FanMainPage() {
     currentIdol,
     isFavorite,
     handleFavoriteToggle,
+    toggleScheduleBookmark,
   } = useFanMainData();
 
   const handleSearchClick = () => navigate('/search');
@@ -80,6 +81,7 @@ export default function FanMainPage() {
             userRole="fan"
             selectedDate={selectedDate.format('YYYY-MM-DD')}
             schedules={filteredSchedules}
+            toggleScheduleBookmark={toggleScheduleBookmark}
           />
         }
       />

--- a/src/pages/main/fan/hooks/useFanMainData.ts
+++ b/src/pages/main/fan/hooks/useFanMainData.ts
@@ -1,14 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import dayjs, { Dayjs } from 'dayjs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
+import {
+  addMySchedule,
+  getBookmarkSchedules,
+  removeMySchedule,
+} from '@/api/bookmarkScheduleApi';
 import { fetchIdolDetail, fetchIdolSchedules } from '@/api/idolApi';
 import { useBookmarkSync } from '@/hooks/useBookmarkSync';
-// ⚠️ TODO(삭제 예정): 스케줄 API가 안정되면 아래 목업 import는 제거
-import { ALL_SCHEDULES } from '@/mocks/data';
 import type { Schedule } from '@/types/schedule';
-import { isGroupSchedule, isIdolSchedule } from '@/types/schedule';
+import { toggleFavorite } from '@/mocks/data/idols';
 
 export function useFanMainData() {
   const { idolId = '' } = useParams<{ idolId: string }>();
@@ -17,7 +20,8 @@ export function useFanMainData() {
   const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs());
   const [filteredSchedules, setFilteredSchedules] = useState<Schedule[]>([]);
 
-  const { favoriteIdols, toggleFavorite } = useBookmarkSync();
+  const { favoriteIdols } = useBookmarkSync();
+  const queryClient = useQueryClient();
 
   const { data: idolDetail } = useQuery({
     queryKey: ['idol', 'detail', parsedIdolId],
@@ -29,6 +33,46 @@ export function useFanMainData() {
     queryKey: ['idol', 'schedules', parsedIdolId],
     enabled: Number.isFinite(parsedIdolId) && parsedIdolId > 0,
     queryFn: () => fetchIdolSchedules(parsedIdolId),
+  });
+
+  const { data: rawBookmarkedSchedules } = useQuery({
+    queryKey: ['myBookmarkEntries'],
+    queryFn: getBookmarkSchedules,
+  });
+
+  const bookmarkedScheduleIds = useMemo(() => {
+    return new Set(
+      rawBookmarkedSchedules?.map(s => s.schedule_details.id) ?? [],
+    );
+  }, [rawBookmarkedSchedules]);
+
+  const { mutate: toggleScheduleBookmark } = useMutation({
+    mutationFn: async (schedule: Schedule) => {
+      if (schedule.isBookmarked) {
+        const bookmarkEntry = rawBookmarkedSchedules?.find(
+          entry => entry.schedule_details.id === schedule.realScheduleId,
+        );
+        if (bookmarkEntry) {
+          await removeMySchedule(bookmarkEntry.id);
+        } else {
+          throw new Error('Bookmark entry not found for schedule ID');
+        }
+      } else {
+        if ('idol' in schedule && schedule.idol) {
+          await addMySchedule({ idol_schedule: schedule.realScheduleId });
+        } else if ('group' in schedule && schedule.group) {
+          await addMySchedule({ group_schedule: schedule.realScheduleId });
+        } else {
+          throw new Error('Cannot bookmark schedule without idol or group ID');
+        }
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['idol', 'schedules', parsedIdolId],
+      });
+      queryClient.invalidateQueries({ queryKey: ['myBookmarkEntries'] });
+    },
   });
 
   const currentIdol = useMemo(
@@ -67,30 +111,13 @@ export function useFanMainData() {
         isPublic: Boolean(it.is_public ?? it.isPublic ?? true),
         idol: { id: currentIdol.id, name: currentIdol.name },
         location: it.location ?? '',
+        isBookmarked: bookmarkedScheduleIds.has(it.id),
+        realScheduleId: it.id,
       }),
     ) as Schedule[];
 
-    if (mappedFromApi.length > 0) {
-      setFilteredSchedules(mappedFromApi);
-      return;
-    }
-
-    // ⚠️ 서버 데이터가 아직 없으면 → 기존 목업 로직으로 fallback
-    const { name: idolName, groupName } = currentIdol;
-
-    const schedulesFromMock = ALL_SCHEDULES.filter(schedule => {
-      if (isIdolSchedule(schedule) && schedule.idol.name === idolName)
-        return true;
-      if (isGroupSchedule(schedule) && schedule.group.name === groupName)
-        return true;
-      if ('members' in schedule) {
-        return schedule.members?.some(member => member.name === idolName);
-      }
-      return false;
-    });
-
-    setFilteredSchedules(schedulesFromMock);
-  }, [currentIdol, idolSchedulesFromApi]);
+    setFilteredSchedules(mappedFromApi);
+  }, [currentIdol, idolSchedulesFromApi, bookmarkedScheduleIds]);
 
   const handleFavoriteToggle = useCallback(() => {
     if (parsedIdolId) toggleFavorite(parsedIdolId);
@@ -104,5 +131,6 @@ export function useFanMainData() {
     currentIdol,
     isFavorite,
     handleFavoriteToggle,
+    toggleScheduleBookmark,
   };
 }

--- a/src/pages/main/fan/hooks/useFanMainData.ts
+++ b/src/pages/main/fan/hooks/useFanMainData.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs, { Dayjs } from 'dayjs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -10,8 +10,8 @@ import {
 } from '@/api/bookmarkScheduleApi';
 import { fetchIdolDetail, fetchIdolSchedules } from '@/api/idolApi';
 import { useBookmarkSync } from '@/hooks/useBookmarkSync';
-import type { Schedule } from '@/types/schedule';
 import { toggleFavorite } from '@/mocks/data/idols';
+import type { Schedule } from '@/types/schedule';
 
 export function useFanMainData() {
   const { idolId = '' } = useParams<{ idolId: string }>();
@@ -57,14 +57,12 @@ export function useFanMainData() {
         } else {
           throw new Error('Bookmark entry not found for schedule ID');
         }
+      } else if ('idol' in schedule && schedule.idol) {
+        await addMySchedule({ idol_schedule: schedule.realScheduleId });
+      } else if ('group' in schedule && schedule.group) {
+        await addMySchedule({ group_schedule: schedule.realScheduleId });
       } else {
-        if ('idol' in schedule && schedule.idol) {
-          await addMySchedule({ idol_schedule: schedule.realScheduleId });
-        } else if ('group' in schedule && schedule.group) {
-          await addMySchedule({ group_schedule: schedule.realScheduleId });
-        } else {
-          throw new Error('Cannot bookmark schedule without idol or group ID');
-        }
+        throw new Error('Cannot bookmark schedule without idol or group ID');
       }
     },
     onSuccess: () => {

--- a/src/stores/favoritesStore.ts
+++ b/src/stores/favoritesStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import { getBookmarkGroups, getBookmarkIdols } from '@/api/bookmarkApi';
+import { getBookmarkGroups, getBookmarkIdols } from '@/api/bookmarkIdolApi';
 import type { BookmarkGroup, BookmarkIdol } from '@/types/bookmark';
 
 interface FavoritesState {

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -23,17 +23,26 @@ export interface BookmarkIdol {
 
 export interface BookmarkSchedule {
   id: number;
-  schedule_id: number;
+  schedule_type: string;
+  schedule_details: string;
+}
+
+export interface RawScheduleContent {
+  id: number;
+  title: string;
   start_time: string;
   end_time: string;
   location: string;
   description: string;
-  entity_type: string;
-  entity_name: string;
+  is_public: boolean;
+  created_at: string;
+  updated_at: string;
+  idol?: number;
+  group?: number;
 }
 
 export interface BookmarkScheduleDetail {
   id: number;
   schedule_type: string;
-  schedule_details: string;
+  schedule_details: RawScheduleContent;
 }

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -24,7 +24,7 @@ export interface BookmarkIdol {
 export interface BookmarkSchedule {
   id: number;
   schedule_type: string;
-  schedule_details: string;
+  schedule_details: RawScheduleContent;
 }
 
 export interface RawScheduleContent {

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -20,3 +20,14 @@ export interface BookmarkIdol {
   idol_name: string;
   created_at: string;
 }
+
+export interface BookmarkSchedule {
+  id: number;
+  schedule_id: number;
+  start_time: string;
+  end_time: string;
+  location: string;
+  description: string;
+  entity_type: string;
+  entity_name: string;
+}

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -31,3 +31,9 @@ export interface BookmarkSchedule {
   entity_type: string;
   entity_name: string;
 }
+
+export interface BookmarkScheduleDetail {
+  id: number;
+  schedule_type: string;
+  schedule_details: string;
+}

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -9,6 +9,7 @@ interface BaseSchedule {
   isNotified?: boolean;
   place?: string;
   location?: string;
+  realScheduleId?: number;
 }
 
 export interface GroupInfo {

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -11,12 +11,12 @@ interface BaseSchedule {
   location?: string;
 }
 
-interface GroupInfo {
+export interface GroupInfo {
   id: number;
   name: string;
 }
 
-interface IdolInfo {
+export interface IdolInfo {
   id: number;
   name: string;
 }


### PR DESCRIPTION
## 🚀 PR 요약

스케줄 찜 조회/추가/수정 api 연결 및 기능 구현

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가
- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

아이돌 스케줄 조회 페이지에서 스케줄 찜 추가 및 삭제 기능
마이페이지에서 찜 스케줄 조회 및 삭제 기능

*msw 목 데이터 사용하는 부분은 제거하였습니다.
*우선 기능 구현에 집중하느라 코드 리팩토링은 못했는데 피드백 남겨주시면 추후에 이슈 생성해서 코드 개선하도록 하겠습니다!

https://github.com/user-attachments/assets/69035776-4d6f-4a2f-945e-4cd0625cf6da

## 🔗 연관된 이슈

> closes #178 
