### PR TITLE
Refactor: 아이돌 & 매니저 메인 페이지 채팅 버튼 리팩토링

### DIFF
--- a/src/pages/main/idol/IdolMainPage.tsx
+++ b/src/pages/main/idol/IdolMainPage.tsx
@@ -1,5 +1,6 @@
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
 import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/common/Button';
 import Calendar from '@/components/common/calendar/Calendar';
@@ -11,10 +12,11 @@ import { useIdolMainData } from './hooks/useIdolMainData';
 export default function IdolMainPage() {
   const { selectedDate, setSelectedDate, filteredSchedules } =
     useIdolMainData();
+  const navigate = useNavigate();
 
   const handleChatClick = useCallback(() => {
-    // TODO: 실제 라우팅 연결 (예: navigate('/chat'))
-  }, []);
+    navigate('/chat');
+  }, [navigate]);
 
   const rightAction = (
     <Button

--- a/src/pages/main/idol/IdolMainPage.tsx
+++ b/src/pages/main/idol/IdolMainPage.tsx
@@ -27,7 +27,7 @@ export default function IdolMainPage() {
       className="group mt-6 flex items-center gap-2 border-fuchsia-400 px-6 font-bold whitespace-nowrap text-fuchsia-600 hover:bg-fuchsia-400 hover:text-white lg:ml-6"
     >
       <ChatBubbleLeftRightIcon className="h-5 w-5 text-fuchsia-500 transition-colors group-hover:text-white" />
-      매니저와 채팅
+      그룹 채팅
     </Button>
   );
 

--- a/src/pages/main/manager/ManagerMainPage.tsx
+++ b/src/pages/main/manager/ManagerMainPage.tsx
@@ -1,6 +1,7 @@
 import { ChatBubbleLeftRightIcon, PlusIcon } from '@heroicons/react/24/solid';
 import dayjs from 'dayjs';
 import { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/common/Button';
 import Calendar from '@/components/common/calendar/Calendar';
@@ -49,6 +50,8 @@ export default function ManagerMainPage() {
     closeDelete,
     resetTarget,
   } = useManagerScheduleModals();
+
+  const navigate = useNavigate();
 
   const handleCreateOpen = useCallback(() => {
     openCreate();
@@ -126,10 +129,8 @@ export default function ManagerMainPage() {
   );
 
   const handleChatClick = useCallback(() => {
-    // TODO: 채팅 페이지로 라우팅 구현 예정
-    // eslint-disable-next-line no-console
-    console.log('아이돌과 채팅으로 이동');
-  }, []);
+    navigate('/chat');
+  }, [navigate]);
 
   const editDefaults: Partial<FormValues> | undefined = useMemo(() => {
     if (targetId == null) return undefined;

--- a/src/pages/main/manager/ManagerMainPage.tsx
+++ b/src/pages/main/manager/ManagerMainPage.tsx
@@ -165,7 +165,7 @@ export default function ManagerMainPage() {
         className="group inline-flex h-12 w-[185px] items-center justify-center gap-2 border-fuchsia-400 px-6 font-semibold whitespace-nowrap hover:bg-fuchsia-500 hover:text-white"
       >
         <ChatBubbleLeftRightIcon className="h-6 w-6 flex-shrink-0 transition-colors group-hover:text-white" />
-        아이돌과 채팅
+        그룹 채팅
       </Button>
     </div>
   );


### PR DESCRIPTION
## 🚀 PR 요약

아이돌 메인 페이지와 채팅 메인 페이지의 채팅 페이지 이동 버튼의 텍스트를 수정하고, 클릭 시 채팅 페이지로 이동하도록 navigate를 추가합니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

채팅 시스템이 기존 기획과 다르게 1대1이 아닌 그룹별 단체 채팅이 되었기 때문에 버튼의 텍스트를 **그룹 채팅**으로 변경했습니다.

간단한 수정이므로 확인 후 이모지 눌러주시면 머지하겠습니다!

## 🔗 연관된 이슈

> closes #187 
