### PR TITLE
Fix: 웹소켓 연결 전 close 실행되지 않도록 수정

### DIFF
--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -101,14 +101,20 @@ function Chat() {
       showErrorToast(`채팅방 연결을 실패했습니다😥`);
     };
 
-    ws.onclose = () => {
-      showErrorToast(`채팅방 연결이 중단됐습니다😓`);
+    ws.onclose = e => {
+      if (e.code === 1006) {
+        showErrorToast(`채팅방 연결이 중단됐습니다😓`);
+      }
     };
 
     setSocket(ws);
 
     // eslint-disable-next-line consistent-return
-    return () => ws.close();
+    return () => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.close();
+      }
+    };
   }, [accessToken, roomId]);
 
   return (


### PR DESCRIPTION
## 🚀 PR 요약

웹 소켓이 연결되기 전에 onclose가 실행되지 않도록 수정했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

useEffect 안의 return 문에서 현재 웹 소켓과 연결이 된 상태인지 확인한 다음 onclose 실행하는 방식으로 에러 해결했습니다.

또한 비정상적인 종료인 1006 코드가 반환될 때만 **채팅방 연결 중단** 토스트 메시지를 띄우도록 수정했습니다.

간단한 수정이므로 확인 후 이모지 눌러주시면 머지하겠습니다.

## 🔗 연관된 이슈

> closes #189 
