### PR TITLE
Feat: 아이돌 메인 페이지 API 연동

### DIFF
--- a/src/api/scheduleApi.ts
+++ b/src/api/scheduleApi.ts
@@ -1,0 +1,72 @@
+import axiosInstance from '@/api/axiosInstance';
+import type { Schedule, IdolSchedule } from '@/types/schedule';
+
+const pickList = (data: any): any[] =>
+  Array.isArray(data?.results) ? data.results : Array.isArray(data) ? data : [];
+
+const baseFields = (raw: any) => {
+  const start =
+    raw?.start_time ?? raw?.startTime ?? raw?.start_at ?? raw?.startAt ?? '';
+  const end = raw?.end_time ?? raw?.endTime ?? raw?.end_at ?? raw?.endAt ?? '';
+
+  return {
+    id: Number(raw?.id ?? Math.random()),
+    title: String(raw?.title ?? ''),
+    startTime: String(start),
+    endTime: String(end),
+    description: raw?.description ? String(raw.description) : '',
+    isPublic: Boolean(raw?.is_public ?? raw?.isPublic ?? true),
+    place: raw?.place ? String(raw.place) : undefined,
+    location: raw?.location ? String(raw.location) : undefined,
+  };
+};
+
+const toIdolSchedule = (raw: any): IdolSchedule => {
+  const base = baseFields(raw);
+
+  const idolId =
+    typeof raw?.idol === 'number'
+      ? raw.idol
+      : typeof raw?.idol?.id === 'number'
+        ? raw.idol.id
+        : -1;
+
+  const idolName =
+    typeof raw?.idol_name === 'string'
+      ? raw.idol_name
+      : typeof raw?.idol?.name === 'string'
+        ? raw.idol.name
+        : '';
+
+  return {
+    ...base,
+    idol: {
+      id: Number(idolId),
+      name: idolName,
+    },
+  };
+};
+
+export async function fetchIdolSchedules(
+  idolId?: number | string,
+  dateISO?: string,
+): Promise<Schedule[]> {
+  const params: Record<string, any> = {};
+  if (idolId !== undefined && idolId !== null) params.idol = idolId;
+  if (dateISO) params.date = dateISO;
+
+  const res = await axiosInstance.get('/schedules/idols/', { params });
+  const list = pickList(res.data);
+  return list.map(toIdolSchedule);
+}
+
+export async function fetchIdolSchedulesByDate(
+  idolId: number | string,
+  dateISO: string,
+): Promise<Schedule[]> {
+  const res = await axiosInstance.get('/schedules/idols/', {
+    params: { idol: idolId, date: dateISO },
+  });
+  const list = pickList(res.data);
+  return list.map(toIdolSchedule);
+}

--- a/src/api/scheduleApi.ts
+++ b/src/api/scheduleApi.ts
@@ -1,8 +1,11 @@
 import axiosInstance from '@/api/axiosInstance';
-import type { Schedule, IdolSchedule } from '@/types/schedule';
+import type { IdolSchedule, Schedule } from '@/types/schedule';
 
-const pickList = (data: any): any[] =>
-  Array.isArray(data?.results) ? data.results : Array.isArray(data) ? data : [];
+const pickList = (data: any): any[] => {
+  if (Array.isArray(data?.results)) return data.results;
+  if (Array.isArray(data)) return data;
+  return [];
+};
 
 const baseFields = (raw: any) => {
   const start =
@@ -24,19 +27,19 @@ const baseFields = (raw: any) => {
 const toIdolSchedule = (raw: any): IdolSchedule => {
   const base = baseFields(raw);
 
-  const idolId =
-    typeof raw?.idol === 'number'
-      ? raw.idol
-      : typeof raw?.idol?.id === 'number'
-        ? raw.idol.id
-        : -1;
+  let idolId = -1;
+  if (typeof raw?.idol === 'number') {
+    idolId = raw.idol;
+  } else if (typeof raw?.idol?.id === 'number') {
+    idolId = raw.idol.id;
+  }
 
-  const idolName =
-    typeof raw?.idol_name === 'string'
-      ? raw.idol_name
-      : typeof raw?.idol?.name === 'string'
-        ? raw.idol.name
-        : '';
+  let idolName = '';
+  if (typeof raw?.idol_name === 'string') {
+    idolName = raw.idol_name;
+  } else if (typeof raw?.idol?.name === 'string') {
+    idolName = raw.idol.name;
+  }
 
   return {
     ...base,

--- a/src/components/common/dateSchedule/DateScheduleItem.tsx
+++ b/src/components/common/dateSchedule/DateScheduleItem.tsx
@@ -125,7 +125,7 @@ export default function DateScheduleItem({
             )}
             <p>날짜: {formatDateSlash(displayDate)}</p>
 
-            {isGroupSchedule(item) && (
+            {userRole !== 'idol' && isGroupSchedule(item) && (
               <p>
                 아티스트: {item.group.name}
                 {item.members &&
@@ -133,7 +133,9 @@ export default function DateScheduleItem({
                   ` (${item.members.map(m => m.name).join(', ')})`}
               </p>
             )}
-            {isIdolSchedule(item) && <p>아티스트: {item.idol.name}</p>}
+            {userRole !== 'idol' && isIdolSchedule(item) && (
+              <p>아티스트: {item.idol.name}</p>
+            )}
 
             {item.description && (
               <p className="mt-2 whitespace-pre-wrap">{item.description}</p>

--- a/src/components/common/dateSchedule/getScheduleActions.ts
+++ b/src/components/common/dateSchedule/getScheduleActions.ts
@@ -40,7 +40,7 @@ export function getScheduleActions(
     onDeleteClick,
   }: Handlers,
 ): ScheduleActionInfo[] {
-  const isBookmarked = item.isBookmarked;
+  const { isBookmarked } = item;
 
   switch (userRole) {
     case 'fan':

--- a/src/pages/main/idol/IdolMainPage.tsx
+++ b/src/pages/main/idol/IdolMainPage.tsx
@@ -1,6 +1,6 @@
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
 
 import { Button } from '@/components/common/Button';
 import Calendar from '@/components/common/calendar/Calendar';
@@ -10,9 +10,15 @@ import { CalendarScheduleLayout, Greeting } from '../shared';
 import { useIdolMainData } from './hooks/useIdolMainData';
 
 export default function IdolMainPage() {
-  const { selectedDate, setSelectedDate, filteredSchedules } =
+  const { selectedDate, setSelectedDate, monthlySchedules, dailySchedules } =
     useIdolMainData();
+
   const navigate = useNavigate();
+
+  const nickname = useMemo(
+    () => sessionStorage.getItem('nickname') || '사용자',
+    [],
+  );
 
   const handleChatClick = useCallback(() => {
     navigate('/chat');
@@ -35,7 +41,7 @@ export default function IdolMainPage() {
     <div className="mx-auto mb-16 max-w-screen-xl px-3 pt-12 md:px-8 lg:mb-24 lg:px-2 lg:pt-6">
       <Greeting
         userRole="idol"
-        title="안녕하세요, 카리나님!"
+        title={`안녕하세요, ${nickname}님!`}
         subtitle="오늘의 스케줄을 확인해보세요."
         rightAction={rightAction}
       />
@@ -46,14 +52,14 @@ export default function IdolMainPage() {
           <Calendar
             selectedDate={selectedDate}
             onDateChange={setSelectedDate}
-            schedules={filteredSchedules}
+            schedules={monthlySchedules}
           />
         }
         daily={
           <DateScheduleList
             userRole="idol"
             selectedDate={selectedDate.format('YYYY-MM-DD')}
-            schedules={filteredSchedules}
+            schedules={dailySchedules}
           />
         }
       />

--- a/src/pages/main/idol/IdolMainPage.tsx
+++ b/src/pages/main/idol/IdolMainPage.tsx
@@ -1,6 +1,6 @@
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
 import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
 
 import { Button } from '@/components/common/Button';
 import Calendar from '@/components/common/calendar/Calendar';

--- a/src/pages/main/idol/hooks/useIdolMainData.ts
+++ b/src/pages/main/idol/hooks/useIdolMainData.ts
@@ -1,40 +1,39 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { useEffect, useMemo, useState } from 'react';
 
-import type { IdolSchedule, Schedule } from '@/types/schedule';
+import { fetchIdolSchedules } from '@/api/scheduleApi';
+import type { Schedule } from '@/types/schedule';
 
 export function useIdolMainData() {
   const [selectedDate, setSelectedDate] = useState<Dayjs>(() => dayjs());
   const [allSchedules, setAllSchedules] = useState<Schedule[]>([]);
 
   useEffect(() => {
-    const iso = selectedDate.format('YYYY-MM-DD');
+    const load = async () => {
+      try {
+        const schedules = await fetchIdolSchedules();
+        setAllSchedules(schedules);
+      } catch (e) {
+        console.error('아이돌 스케줄 불러오기 실패:', e);
+        setAllSchedules([]);
+      }
+    };
+    load();
+  }, []);
 
-    // TODO: API 연동: GET /idol/me/schedules?date=iso
-    const mock: IdolSchedule[] = [
-      {
-        id: 1,
-        title: '라디오 출연',
-        startTime: `${iso}T09:30:00`,
-        endTime: `${iso}T10:30:00`,
-        isPublic: true,
-        idol: { id: 101, name: '아이돌 A' },
-        description: 'SBS 파워FM 생방',
-      },
-      {
-        id: 2,
-        title: '안무 연습',
-        startTime: `${iso}T14:00:00`,
-        endTime: `${iso}T16:00:00`,
-        isPublic: true,
-        idol: { id: 101, name: '아이돌 A' },
-      },
-    ];
+  const monthlySchedules = useMemo(
+    () =>
+      allSchedules.filter(s =>
+        dayjs(s.startTime).isSame(selectedDate, 'month'),
+      ),
+    [allSchedules, selectedDate],
+  );
 
-    setAllSchedules(mock as Schedule[]);
-  }, [selectedDate]);
+  const dailySchedules = useMemo(
+    () =>
+      allSchedules.filter(s => dayjs(s.startTime).isSame(selectedDate, 'day')),
+    [allSchedules, selectedDate],
+  );
 
-  const filteredSchedules = useMemo(() => allSchedules, [allSchedules]);
-
-  return { selectedDate, setSelectedDate, filteredSchedules };
+  return { selectedDate, setSelectedDate, monthlySchedules, dailySchedules };
 }

--- a/src/pages/main/idol/hooks/useIdolMainData.ts
+++ b/src/pages/main/idol/hooks/useIdolMainData.ts
@@ -13,8 +13,7 @@ export function useIdolMainData() {
       try {
         const schedules = await fetchIdolSchedules();
         setAllSchedules(schedules);
-      } catch (e) {
-        console.error('아이돌 스케줄 불러오기 실패:', e);
+      } catch (err) {
         setAllSchedules([]);
       }
     };

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -7,6 +7,7 @@ interface User {
   nickname: string;
   profile_image_url?: string;
   role?: string;
+  idol_id?: number;
 }
 
 interface UserState {
@@ -34,6 +35,8 @@ export const useUserStore = create<UserState>()(
           refreshToken: refreshToken || '',
         });
         // console.log('useUserStore: login action - state after set:', get());
+        const nick = user.nickname || user.email || '사용자';
+        sessionStorage.setItem('nickname', nick);
       },
       logout: () => {
         set({


### PR DESCRIPTION
## 🚀 PR 요약

아이돌 메인 페이지에서 로그인한 유저 닉네임을 표시하고,  
`GET /api/v1/schedules/idols/` API를 연동하여 스케줄을 보여주도록 수정했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가


## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다. (#173)
- [x] 실행에 문제가 없는지 테스트했습니다.
- [x] 이슈 브랜치 -> develop PR은 **squash and merge**, develop -> main PR은 **rebase and merge**를 선택했습니다.

## 🗒️ 기타 참고사항

- 로그인 성공 시 `sessionStorage`에 닉네임 저장 후 Greeting에서 표시합니다.  
- useIdolMainData 훅을 API 연동 중심으로 수정했습니다.  
- 백엔드에서 idol 스케줄 API (`/schedules/idols/`) 응답 형태를 기준으로 매핑했습니다.
- 코드가 썩 좋아보이진 않지만...🥲
- 스크린 이미지
![Vite + React + TS (3) mp4 (1)](https://github.com/user-attachments/assets/b6f1a6ea-018f-47d3-926f-60491ff731b1)



## 🔗 연관된 이슈

closes #173
